### PR TITLE
useStateで実装

### DIFF
--- a/src/component/common/template/Card/Card.props.ts
+++ b/src/component/common/template/Card/Card.props.ts
@@ -2,12 +2,10 @@ import { createLightProps } from '../../part/Icon/Icon.props';
 import { CardDataProps } from './Card.type';
 
 export const toDoProps: CardDataProps = {
-  type: 'TO DO',
   createLightIcon: createLightProps,
 };
 
 export const completedProps: CardDataProps = {
-  type: 'COMPLETED',
   createLightIcon: createLightProps,
 };
 

--- a/src/component/common/template/Card/Card.props.ts
+++ b/src/component/common/template/Card/Card.props.ts
@@ -1,17 +1,17 @@
 import { createLightProps } from '../../part/Icon/Icon.props';
-import { CardProps } from './Card';
+import { CardDataProps } from './Card.type';
 
-export const toDoProps: CardProps = {
+export const toDoProps: CardDataProps = {
   type: 'TO DO',
   createLightIcon: createLightProps,
 };
 
-export const completedProps: CardProps = {
+export const completedProps: CardDataProps = {
   type: 'COMPLETED',
   createLightIcon: createLightProps,
 };
 
-export const propObj: { [key: string]: CardProps } = {
+export const propObj: { [key: string]: CardDataProps } = {
   toDo: toDoProps,
   completed: completedProps,
 };

--- a/src/component/common/template/Card/Card.stories.tsx
+++ b/src/component/common/template/Card/Card.stories.tsx
@@ -11,6 +11,6 @@ export default {
 const Template: Story<CardProps> = (args) => <Card {...args} />;
 
 export const ToDo = Template.bind({});
-ToDo.args = propObj.toDo;
+ToDo.args = { ...propObj.toDo, type: 'TO DO' };
 export const Completed = Template.bind({});
-Completed.args = propObj.completed;
+Completed.args = { ...propObj.completed, type: 'COMPLETED' };

--- a/src/component/common/template/Card/Card.stories.tsx
+++ b/src/component/common/template/Card/Card.stories.tsx
@@ -1,16 +1,21 @@
 import type { ComponentMeta, Story } from '@storybook/react';
+import { createLightProps } from '../../part/Icon/Icon.props';
+import { Card } from './Card';
 import { propObj } from './Card.props';
-import { CardProps } from './Card.type';
-import { Card } from './index';
+import { CardPresenterProps } from './Card.type';
 
 export default {
   title: 'Common/template/Card',
   component: Card,
 } as ComponentMeta<typeof Card>;
 
-const Template: Story<CardProps> = (args) => <Card {...args} />;
+const Template: Story<CardPresenterProps> = (args) => <Card {...args} />;
 
 export const ToDo = Template.bind({});
-ToDo.args = { ...propObj.toDo, type: 'TO DO' };
+ToDo.args = {
+  createLightIcon: createLightProps,
+  type: 'TO DO',
+  toDos: [{ isCompleted: false, title: 'name', description: 'description' }],
+};
 export const Completed = Template.bind({});
 Completed.args = { ...propObj.completed, type: 'COMPLETED' };

--- a/src/component/common/template/Card/Card.stories.tsx
+++ b/src/component/common/template/Card/Card.stories.tsx
@@ -18,4 +18,8 @@ ToDo.args = {
   toDos: [{ isCompleted: false, title: 'name', description: 'description', id: -1 }],
 };
 export const Completed = Template.bind({});
-Completed.args = { ...propObj.completed, type: 'COMPLETED' };
+Completed.args = {
+  ...propObj.completed,
+  type: 'COMPLETED',
+  toDos: [{ isCompleted: false, title: 'name', description: 'description', id: -1 }],
+};

--- a/src/component/common/template/Card/Card.stories.tsx
+++ b/src/component/common/template/Card/Card.stories.tsx
@@ -15,7 +15,7 @@ export const ToDo = Template.bind({});
 ToDo.args = {
   createLightIcon: createLightProps,
   type: 'TO DO',
-  toDos: [{ isCompleted: false, title: 'name', description: 'description' }],
+  toDos: [{ isCompleted: false, title: 'name', description: 'description', id: -1 }],
 };
 export const Completed = Template.bind({});
 Completed.args = { ...propObj.completed, type: 'COMPLETED' };

--- a/src/component/common/template/Card/Card.stories.tsx
+++ b/src/component/common/template/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { Card, CardProps } from './Card';
+import { Card, CardFcProps } from './Card';
 import { propObj } from './Card.props';
 
 export default {
@@ -7,7 +7,7 @@ export default {
   component: Card,
 } as ComponentMeta<typeof Card>;
 
-const Template: Story<CardProps> = (args) => <Card {...args} />;
+const Template: Story<CardFcProps> = (args) => <Card {...args} />;
 
 export const ToDo = Template.bind({});
 ToDo.args = propObj.toDo;

--- a/src/component/common/template/Card/Card.stories.tsx
+++ b/src/component/common/template/Card/Card.stories.tsx
@@ -1,13 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { Card, CardFcProps } from './Card';
 import { propObj } from './Card.props';
+import { CardProps } from './Card.type';
+import { Card } from './index';
 
 export default {
   title: 'Common/template/Card',
   component: Card,
 } as ComponentMeta<typeof Card>;
 
-const Template: Story<CardFcProps> = (args) => <Card {...args} />;
+const Template: Story<CardProps> = (args) => <Card {...args} />;
 
 export const ToDo = Template.bind({});
 ToDo.args = propObj.toDo;

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -17,9 +17,9 @@ export const Card: React.FC<CardPresenterProps> = ({
           <span className='tag bg-primary-700'>{type}</span>
           <div className='-mt-2 flex w-[360px] flex-col gap-y-2 bg-white px-8 py-4 shadow-md shadow-primary-200'>
             <div className='flex justify-end'>
-              <span className='justify-self-end' onClick={handleClick}>
+              <button className='justify-self-end' onClick={handleClick}>
                 <Icon {...createLightIcon} />
-              </span>
+              </button>
             </div>
             {toDos
               .filter((v) => v.isCompleted === false)

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -1,15 +1,19 @@
 import { Icon, IconProps } from '@/component/common/part/Icon';
-import { useTodos } from '@/hook/useTodos';
+import { ToDoProps } from '@/hook/useTodos';
 
 export interface CardProps {
   type: 'TO DO' | 'COMPLETED';
   createLightIcon: IconProps;
 }
 
+export interface CardFcProps extends CardProps {
+  toDos: ToDoProps[];
+  handleClick: () => void;
+}
+
 export const baseId = 'common-template-card';
 
-export const Card: React.FC<CardProps> = ({ type, createLightIcon }) => {
-  const { toDos, handleClick } = useTodos();
+export const Card: React.FC<CardFcProps> = ({ type, createLightIcon, toDos, handleClick }) => {
   switch (type) {
     case 'TO DO':
       return (

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -8,7 +8,7 @@ export const Card: React.FC<CardPresenterProps> = ({
   createLightIcon,
   toDos,
   handleClick,
-  descriptionClick,
+  selectClick,
 }) => {
   switch (type) {
     case 'TO DO':
@@ -21,22 +21,21 @@ export const Card: React.FC<CardPresenterProps> = ({
                 <Icon {...createLightIcon} />
               </span>
             </div>
-            {toDos &&
-              toDos
-                .filter((v) => v.isCompleted === false)
-                .map((toDo, i) => (
-                  <div className='flex items-center gap-x-3' key={i}>
-                    <input
-                      type='checkbox'
-                      className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
-                      defaultChecked={toDo.isCompleted}
-                    />
+            {toDos
+              .filter((v) => v.isCompleted === false)
+              .map((toDo, i) => (
+                <div className='flex items-center gap-x-3' key={i}>
+                  <input
+                    type='checkbox'
+                    className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
+                    defaultChecked={toDo.isCompleted}
+                  />
 
-                    <button className='font-bold text-primary-700' onClick={descriptionClick}>
-                      {toDo.title}
-                    </button>
-                  </div>
-                ))}
+                  <button className='font-bold text-primary-700' onClick={() => selectClick(i)}>
+                    {toDo.title}
+                  </button>
+                </div>
+              ))}
           </div>
         </div>
       );

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -43,11 +43,12 @@ export const Card: React.FC<CardPresenterProps> = ({
       return (
         <div>
           <span className='tag bg-pink-700'>{type}</span>
-          <div className='-mt-2 flex w-[360px] flex-col gap-y-2 bg-white px-8 py-4 shadow-md shadow-primary-200'>
+          <div className='-mt-2 flex w-[360px] flex-col gap-y-2 bg-white px-8 pt-10 pb-4 shadow-md shadow-primary-200'>
             <div className='flex justify-end'>
-              <span className='justify-self-end' onClick={handleClick}>
+              {/* <span className='justify-self-end' onClick={handleClick}>
                 <Icon {...createLightIcon} />
-              </span>
+              </span> */}
+              {/* completedに直接追加することは考えにくいので消去 */}
             </div>
             {toDos &&
               toDos

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -8,6 +8,7 @@ export const Card: React.FC<CardPresenterProps> = ({
   createLightIcon,
   toDos,
   handleClick,
+  descriptionClick,
 }) => {
   switch (type) {
     case 'TO DO':
@@ -31,7 +32,9 @@ export const Card: React.FC<CardPresenterProps> = ({
                       defaultChecked={toDo.isCompleted}
                     />
 
-                    <button className='font-bold text-primary-700'>{toDo.title}</button>
+                    <button className='font-bold text-primary-700' onClick={descriptionClick}>
+                      {toDo.title}
+                    </button>
                   </div>
                 ))}
           </div>

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -9,6 +9,7 @@ export const Card: React.FC<CardPresenterProps> = ({
   toDos,
   handleClick,
   selectClick,
+  handleCheck,
 }) => {
   switch (type) {
     case 'TO DO':
@@ -28,7 +29,8 @@ export const Card: React.FC<CardPresenterProps> = ({
                   <input
                     type='checkbox'
                     className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
-                    defaultChecked={toDo.isCompleted}
+                    checked={toDo.isCompleted}
+                    onChange={(e) => handleCheck(e.target.checked, i)}
                   />
 
                   <button className='font-bold text-primary-700' onClick={() => selectClick(i)}>
@@ -58,9 +60,13 @@ export const Card: React.FC<CardPresenterProps> = ({
                     <input
                       type='checkbox'
                       className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
-                      defaultChecked={toDo.isCompleted}
+                      checked={toDo.isCompleted}
+                      onChange={(e) => handleCheck(e.target.checked, i)}
                     />
-                    <span className='font-bold text-primary-700'>{toDo.title}</span>
+
+                    <button className='font-bold text-primary-700' onClick={() => selectClick(i)}>
+                      {toDo.title}
+                    </button>
                   </div>
                 ))}
           </div>

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -1,19 +1,14 @@
-import { Icon, IconProps } from '@/component/common/part/Icon';
-import { ToDoProps } from '@/hook/useTodos';
-
-export interface CardProps {
-  type: 'TO DO' | 'COMPLETED';
-  createLightIcon: IconProps;
-}
-
-export interface CardFcProps extends CardProps {
-  toDos?: ToDoProps[];
-  handleClick?: () => void;
-}
+import { CardPresenterProps } from './Card.type';
+import { Icon } from '@/component/common/part/Icon';
 
 export const baseId = 'common-template-card';
 
-export const Card: React.FC<CardFcProps> = ({ type, createLightIcon, toDos, handleClick }) => {
+export const Card: React.FC<CardPresenterProps> = ({
+  type,
+  createLightIcon,
+  toDos,
+  handleClick,
+}) => {
   switch (type) {
     case 'TO DO':
       return (
@@ -36,7 +31,7 @@ export const Card: React.FC<CardFcProps> = ({ type, createLightIcon, toDos, hand
                       defaultChecked={toDo.isCompleted}
                     />
 
-                    <span className='font-bold text-primary-700'>{toDo.title}</span>
+                    <button className='font-bold text-primary-700'>{toDo.title}</button>
                   </div>
                 ))}
           </div>

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -7,8 +7,8 @@ export interface CardProps {
 }
 
 export interface CardFcProps extends CardProps {
-  toDos: ToDoProps[];
-  handleClick: () => void;
+  toDos?: ToDoProps[];
+  handleClick?: () => void;
 }
 
 export const baseId = 'common-template-card';
@@ -25,19 +25,20 @@ export const Card: React.FC<CardFcProps> = ({ type, createLightIcon, toDos, hand
                 <Icon {...createLightIcon} />
               </span>
             </div>
-            {toDos
-              .filter((v) => v.isCompleted === false)
-              .map((toDo, i) => (
-                <div className='flex items-center gap-x-3' key={i}>
-                  <input
-                    type='checkbox'
-                    className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
-                    defaultChecked={toDo.isCompleted}
-                  />
+            {toDos &&
+              toDos
+                .filter((v) => v.isCompleted === false)
+                .map((toDo, i) => (
+                  <div className='flex items-center gap-x-3' key={i}>
+                    <input
+                      type='checkbox'
+                      className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
+                      defaultChecked={toDo.isCompleted}
+                    />
 
-                  <span className='font-bold text-primary-700'>{toDo.title}</span>
-                </div>
-              ))}
+                    <span className='font-bold text-primary-700'>{toDo.title}</span>
+                  </div>
+                ))}
           </div>
         </div>
       );
@@ -51,18 +52,19 @@ export const Card: React.FC<CardFcProps> = ({ type, createLightIcon, toDos, hand
                 <Icon {...createLightIcon} />
               </span>
             </div>
-            {toDos
-              .filter((v) => v.isCompleted === true)
-              .map((toDo, i) => (
-                <div className='flex items-center gap-x-3' key={i}>
-                  <input
-                    type='checkbox'
-                    className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
-                    defaultChecked={toDo.isCompleted}
-                  />
-                  <span className='font-bold text-primary-700'>{toDo.title}</span>
-                </div>
-              ))}
+            {toDos &&
+              toDos
+                .filter((v) => v.isCompleted === true)
+                .map((toDo, i) => (
+                  <div className='flex items-center gap-x-3' key={i}>
+                    <input
+                      type='checkbox'
+                      className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
+                      defaultChecked={toDo.isCompleted}
+                    />
+                    <span className='font-bold text-primary-700'>{toDo.title}</span>
+                  </div>
+                ))}
           </div>
         </div>
       );

--- a/src/component/common/template/Card/Card.tsx
+++ b/src/component/common/template/Card/Card.tsx
@@ -24,16 +24,18 @@ export const Card: React.FC<CardPresenterProps> = ({
             </div>
             {toDos
               .filter((v) => v.isCompleted === false)
-              .map((toDo, i) => (
-                <div className='flex items-center gap-x-3' key={i}>
+              .map((toDo) => (
+                <div className='flex items-center gap-x-3' key={toDo.id}>
                   <input
                     type='checkbox'
                     className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
                     checked={toDo.isCompleted}
-                    onChange={(e) => handleCheck(e.target.checked, i)}
+                    onChange={(e) => handleCheck(e.target.checked, toDo.id)}
                   />
-
-                  <button className='font-bold text-primary-700' onClick={() => selectClick(i)}>
+                  <button
+                    className='font-bold text-primary-700'
+                    onClick={() => selectClick(toDo.id)}
+                  >
                     {toDo.title}
                   </button>
                 </div>
@@ -52,23 +54,24 @@ export const Card: React.FC<CardPresenterProps> = ({
               </span> */}
               {/* completedに直接追加することは考えにくいので消去 */}
             </div>
-            {toDos &&
-              toDos
-                .filter((v) => v.isCompleted === true)
-                .map((toDo, i) => (
-                  <div className='flex items-center gap-x-3' key={i}>
-                    <input
-                      type='checkbox'
-                      className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
-                      checked={toDo.isCompleted}
-                      onChange={(e) => handleCheck(e.target.checked, i)}
-                    />
-
-                    <button className='font-bold text-primary-700' onClick={() => selectClick(i)}>
-                      {toDo.title}
-                    </button>
-                  </div>
-                ))}
+            {toDos
+              .filter((v) => v.isCompleted === true)
+              .map((toDo) => (
+                <div className='flex items-center gap-x-3' key={toDo.id}>
+                  <input
+                    type='checkbox'
+                    className='rounded-sm border-primary-700 text-primary-700 focus:ring-transparent'
+                    checked={toDo.isCompleted}
+                    onChange={(e) => handleCheck(e.target.checked, toDo.id)}
+                  />
+                  <button
+                    className='font-bold text-primary-700'
+                    onClick={() => selectClick(toDo.id)}
+                  >
+                    {toDo.title}
+                  </button>
+                </div>
+              ))}
           </div>
         </div>
       );

--- a/src/component/common/template/Card/Card.type.ts
+++ b/src/component/common/template/Card/Card.type.ts
@@ -9,19 +9,23 @@ export interface CardDataProps {
 export interface CardPresenterProps extends CardDataProps {
   toDos: ToDoProps[];
   handleClick: () => void;
+  descriptionClick: () => void;
 }
 
 export interface CardContainerProps {
   toDos: ToDoProps[];
   handleClick: () => void;
+  descriptionClick: () => void;
 }
 
 export interface CardProps extends CardDataProps {
   toDos: ToDoProps[];
   handleClick: () => void;
+  descriptionClick: () => void;
 }
 
 export interface LogicProps {
   toDos: ToDoProps[];
   handleClick: () => void;
+  descriptionClick: () => void;
 }

--- a/src/component/common/template/Card/Card.type.ts
+++ b/src/component/common/template/Card/Card.type.ts
@@ -1,0 +1,27 @@
+import { IconProps } from '@/component/common/part/Icon';
+import { ToDoProps } from '@/hook/useTodos';
+
+export interface CardDataProps {
+  type: 'TO DO' | 'COMPLETED';
+  createLightIcon: IconProps;
+}
+
+export interface CardPresenterProps extends CardDataProps {
+  toDos: ToDoProps[];
+  handleClick: () => void;
+}
+
+export interface CardContainerProps {
+  toDos: ToDoProps[];
+  handleClick: () => void;
+}
+
+export interface CardProps extends CardDataProps {
+  toDos: ToDoProps[];
+  handleClick: () => void;
+}
+
+export interface LogicProps {
+  toDos: ToDoProps[];
+  handleClick: () => void;
+}

--- a/src/component/common/template/Card/Card.type.ts
+++ b/src/component/common/template/Card/Card.type.ts
@@ -11,6 +11,7 @@ export interface CardPresenterProps extends CardDataProps {
   toDos: ToDoProps[];
   handleClick: () => void;
   selectClick: (i: number) => void;
+  handleCheck: (checked: boolean, i: number) => void;
 }
 
 export interface CardContainerProps {
@@ -20,6 +21,7 @@ export interface CardContainerProps {
   descriptionClick: () => void;
   setSelectToDo: Dispatch<SetStateAction<string>>;
   selectToDo: string;
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
 export interface LogicProps {
@@ -27,4 +29,5 @@ export interface LogicProps {
   toDos: ToDoProps[];
   handleClick: () => void;
   selectClick: (i: number) => void;
+  handleCheck: (checked: boolean, i: number) => void;
 }

--- a/src/component/common/template/Card/Card.type.ts
+++ b/src/component/common/template/Card/Card.type.ts
@@ -1,31 +1,39 @@
+import { Dispatch, SetStateAction } from 'react';
 import { IconProps } from '@/component/common/part/Icon';
 import { ToDoProps } from '@/hook/useTodos';
 
 export interface CardDataProps {
-  type: 'TO DO' | 'COMPLETED';
   createLightIcon: IconProps;
 }
 
 export interface CardPresenterProps extends CardDataProps {
+  type: 'TO DO' | 'COMPLETED';
   toDos: ToDoProps[];
   handleClick: () => void;
-  descriptionClick: () => void;
+  selectClick: (i: number) => void;
 }
 
 export interface CardContainerProps {
+  type: 'TO DO' | 'COMPLETED';
   toDos: ToDoProps[];
   handleClick: () => void;
   descriptionClick: () => void;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
+  selectToDo: string;
 }
 
 export interface CardProps extends CardDataProps {
+  type: 'TO DO' | 'COMPLETED';
   toDos: ToDoProps[];
   handleClick: () => void;
   descriptionClick: () => void;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
+  selectClick: (i: number) => void;
 }
 
 export interface LogicProps {
+  type: 'TO DO' | 'COMPLETED';
   toDos: ToDoProps[];
   handleClick: () => void;
-  descriptionClick: () => void;
+  selectClick: (i: number) => void;
 }

--- a/src/component/common/template/Card/Card.type.ts
+++ b/src/component/common/template/Card/Card.type.ts
@@ -29,6 +29,7 @@ export interface CardProps extends CardDataProps {
   descriptionClick: () => void;
   setSelectToDo: Dispatch<SetStateAction<string>>;
   selectClick: (i: number) => void;
+  selectToDo: string;
 }
 
 export interface LogicProps {

--- a/src/component/common/template/Card/Card.type.ts
+++ b/src/component/common/template/Card/Card.type.ts
@@ -22,16 +22,6 @@ export interface CardContainerProps {
   selectToDo: string;
 }
 
-export interface CardProps extends CardDataProps {
-  type: 'TO DO' | 'COMPLETED';
-  toDos: ToDoProps[];
-  handleClick: () => void;
-  descriptionClick: () => void;
-  setSelectToDo: Dispatch<SetStateAction<string>>;
-  selectClick: (i: number) => void;
-  selectToDo: string;
-}
-
 export interface LogicProps {
   type: 'TO DO' | 'COMPLETED';
   toDos: ToDoProps[];

--- a/src/component/common/template/Card/index.tsx
+++ b/src/component/common/template/Card/index.tsx
@@ -1,6 +1,7 @@
 import { Card as CardPresenter } from './Card';
 import { propObj } from './Card.props';
 import { CardContainerProps, CardDataProps, LogicProps } from './Card.type';
+import { ToDoProps } from '@/hook/useTodos';
 
 const Card: React.FC<CardContainerProps> = ({
   type,
@@ -9,17 +10,24 @@ const Card: React.FC<CardContainerProps> = ({
   descriptionClick,
   setSelectToDo,
   selectToDo,
+  setToDos,
 }) => {
   const selectClick = (i: number): void => {
     setSelectToDo(`${i}`);
     descriptionClick();
     console.log(selectToDo);
   };
+  const handleCheck = (checked: boolean, i: number): void => {
+    const newToDos: ToDoProps[] = [...toDos];
+    newToDos[i] = { ...newToDos[i], isCompleted: checked };
+    setToDos(newToDos);
+  };
   const logicProps: LogicProps = {
     type: type,
     toDos: toDos,
     handleClick: handleClick,
     selectClick: selectClick,
+    handleCheck: handleCheck,
   };
   const defaultProps: CardDataProps = { ...propObj.toDo };
   return <CardPresenter {...defaultProps} {...logicProps} />;

--- a/src/component/common/template/Card/index.tsx
+++ b/src/component/common/template/Card/index.tsx
@@ -1,9 +1,14 @@
-import { Card as CardPresenter, CardProps } from './Card';
+import { Card as CardPresenter } from './Card';
 import { propObj } from './Card.props';
+import { CardContainerProps, CardDataProps, LogicProps } from './Card.type';
 
-const Card: React.FC = () => {
-  const defaultProps: CardProps = { ...propObj.toDo };
-  return <CardPresenter {...defaultProps} />;
+const Card: React.FC<CardContainerProps> = ({ toDos, handleClick }) => {
+  const logicProps: LogicProps = {
+    toDos: toDos,
+    handleClick: handleClick,
+  };
+  const defaultProps: CardDataProps = { ...propObj.toDo };
+  return <CardPresenter {...defaultProps} {...logicProps} />;
 };
 
 export { Card };

--- a/src/component/common/template/Card/index.tsx
+++ b/src/component/common/template/Card/index.tsx
@@ -2,10 +2,11 @@ import { Card as CardPresenter } from './Card';
 import { propObj } from './Card.props';
 import { CardContainerProps, CardDataProps, LogicProps } from './Card.type';
 
-const Card: React.FC<CardContainerProps> = ({ toDos, handleClick }) => {
+const Card: React.FC<CardContainerProps> = ({ toDos, handleClick, descriptionClick }) => {
   const logicProps: LogicProps = {
     toDos: toDos,
     handleClick: handleClick,
+    descriptionClick: descriptionClick,
   };
   const defaultProps: CardDataProps = { ...propObj.toDo };
   return <CardPresenter {...defaultProps} {...logicProps} />;

--- a/src/component/common/template/Card/index.tsx
+++ b/src/component/common/template/Card/index.tsx
@@ -2,11 +2,24 @@ import { Card as CardPresenter } from './Card';
 import { propObj } from './Card.props';
 import { CardContainerProps, CardDataProps, LogicProps } from './Card.type';
 
-const Card: React.FC<CardContainerProps> = ({ toDos, handleClick, descriptionClick }) => {
+const Card: React.FC<CardContainerProps> = ({
+  type,
+  toDos,
+  handleClick,
+  descriptionClick,
+  setSelectToDo,
+  selectToDo,
+}) => {
+  const selectClick = (i: number): void => {
+    setSelectToDo(`${i}`);
+    descriptionClick();
+    console.log(selectToDo);
+  };
   const logicProps: LogicProps = {
+    type: type,
     toDos: toDos,
     handleClick: handleClick,
-    descriptionClick: descriptionClick,
+    selectClick: selectClick,
   };
   const defaultProps: CardDataProps = { ...propObj.toDo };
   return <CardPresenter {...defaultProps} {...logicProps} />;

--- a/src/component/common/template/Card/index.tsx
+++ b/src/component/common/template/Card/index.tsx
@@ -13,13 +13,15 @@ const Card: React.FC<CardContainerProps> = ({
   setToDos,
 }) => {
   const selectClick = (i: number): void => {
-    setSelectToDo(`${i}`);
+    const index: number = toDos.findIndex((v) => v.id === i);
+    setSelectToDo(`${index}`);
     descriptionClick();
     console.log(selectToDo);
   };
   const handleCheck = (checked: boolean, i: number): void => {
     const newToDos: ToDoProps[] = [...toDos];
-    newToDos[i] = { ...newToDos[i], isCompleted: checked };
+    const index: number = newToDos.findIndex((v) => v.id === i);
+    newToDos[index] = { ...newToDos[index], isCompleted: checked };
     setToDos(newToDos);
   };
   const logicProps: LogicProps = {

--- a/src/component/common/template/DeleteModal/DeleteModal.props.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.props.ts
@@ -3,7 +3,6 @@ import { DeleteModalDataProps } from './DeleteModal.type';
 
 const defaultProps: DeleteModalDataProps = {
   deleteDeepIcon: deleteDeepProps,
-  title: '経営の必読書を読む',
 };
 
 /**

--- a/src/component/common/template/DeleteModal/DeleteModal.props.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.props.ts
@@ -1,7 +1,7 @@
 import { deleteDeepProps } from '../../part/Icon/Icon.props';
-import { DeleteModalProps } from './DeleteModal';
+import { DeleteModalDataProps } from './DeleteModal.type';
 
-const defaultProps: DeleteModalProps = {
+const defaultProps: DeleteModalDataProps = {
   deleteDeepIcon: deleteDeepProps,
   title: '経営の必読書を読む',
 };
@@ -24,6 +24,6 @@ export const propObj: PropObj = {
   ...
 }*/
 
-export const propObj: { [key: string]: DeleteModalProps } = {
+export const propObj: { [key: string]: DeleteModalDataProps } = {
   default: defaultProps,
 };

--- a/src/component/common/template/DeleteModal/DeleteModal.stories.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.stories.tsx
@@ -11,4 +11,7 @@ export default {
 const Template: Story<DeleteModalPresenterProps> = (args) => <DeleteModal {...args} />;
 
 export const Default = Template.bind({});
-Default.args = propObj.default;
+Default.args = {
+  ...propObj.default,
+  toDo: { title: '経営の必読書を読む', description: '起業のファイナンス', isCompleted: false },
+};

--- a/src/component/common/template/DeleteModal/DeleteModal.stories.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.stories.tsx
@@ -1,13 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { DeleteModal, DeleteModalProps } from './DeleteModal';
+import { DeleteModal } from './DeleteModal';
 import { propObj } from './DeleteModal.props';
+import { DeleteModalPresenterProps } from './DeleteModal.type';
 
 export default {
   title: 'Common/template/DeleteModal',
   component: DeleteModal,
 } as ComponentMeta<typeof DeleteModal>;
 
-const Template: Story<DeleteModalProps> = (args) => <DeleteModal {...args} />;
+const Template: Story<DeleteModalPresenterProps> = (args) => <DeleteModal {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/DeleteModal/DeleteModal.stories.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.stories.tsx
@@ -13,5 +13,10 @@ const Template: Story<DeleteModalPresenterProps> = (args) => <DeleteModal {...ar
 export const Default = Template.bind({});
 Default.args = {
   ...propObj.default,
-  toDo: { title: '経営の必読書を読む', description: '起業のファイナンス', isCompleted: false },
+  toDo: {
+    title: '経営の必読書を読む',
+    description: '起業のファイナンス',
+    isCompleted: false,
+    id: -1,
+  },
 };

--- a/src/component/common/template/DeleteModal/DeleteModal.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.tsx
@@ -8,6 +8,7 @@ export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
   title,
   clearModal,
   descriptionClick,
+  onDeleteClick,
 }) => (
   <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50 opacity-90 '>
     <div className='w-80 bg-white p-4 font-bold text-primary-800 shadow-sm shadow-primary-200'>
@@ -24,7 +25,9 @@ export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
             <button className='btn green-gradient' onClick={descriptionClick}>
               キャンセル
             </button>
-            <button className='btn pink-gradient'>削除</button>
+            <button className='btn pink-gradient' onClick={onDeleteClick}>
+              削除
+            </button>
           </div>
         </div>
       </div>

--- a/src/component/common/template/DeleteModal/DeleteModal.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.tsx
@@ -7,6 +7,7 @@ export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
   deleteDeepIcon,
   title,
   clearModal,
+  descriptionClick,
 }) => (
   <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50 opacity-90 '>
     <div className='w-80 bg-white p-4 font-bold text-primary-800 shadow-sm shadow-primary-200'>
@@ -20,7 +21,9 @@ export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
           <div className='text-lg'>{title}</div>
           本当に削除しますか？
           <div className='mx-auto mb-4 flex flex-row gap-x-4'>
-            <button className='btn green-gradient'>キャンセル</button>
+            <button className='btn green-gradient' onClick={descriptionClick}>
+              キャンセル
+            </button>
             <button className='btn pink-gradient'>削除</button>
           </div>
         </div>

--- a/src/component/common/template/DeleteModal/DeleteModal.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.tsx
@@ -1,17 +1,19 @@
-import { Icon, IconProps } from '../../part/Icon';
-
-export interface DeleteModalProps {
-  deleteDeepIcon: IconProps;
-  title: string;
-}
+import { Icon } from '../../part/Icon';
+import { DeleteModalPresenterProps } from './DeleteModal.type';
 
 export const baseId = 'common-template-delete-modal';
 
-export const DeleteModal: React.FC<DeleteModalProps> = ({ deleteDeepIcon, title }) => (
+export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
+  deleteDeepIcon,
+  title,
+  clearModal,
+}) => (
   <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50 opacity-90 '>
     <div className='w-80 bg-white p-4 font-bold text-primary-800 shadow-sm shadow-primary-200'>
-      <div className='mb-4 text-right'>
-        <Icon {...deleteDeepIcon} />
+      <div className='mb-4 flex justify-end'>
+        <button className='justify-self-end' onClick={clearModal}>
+          <Icon {...deleteDeepIcon} />
+        </button>
       </div>
       <div className='mx-auto px-8'>
         <div className='flex flex-col gap-y-4'>

--- a/src/component/common/template/DeleteModal/DeleteModal.tsx
+++ b/src/component/common/template/DeleteModal/DeleteModal.tsx
@@ -5,12 +5,12 @@ export const baseId = 'common-template-delete-modal';
 
 export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
   deleteDeepIcon,
-  title,
   clearModal,
   descriptionClick,
   onDeleteClick,
+  toDo,
 }) => (
-  <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50 opacity-90 '>
+  <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50/90'>
     <div className='w-80 bg-white p-4 font-bold text-primary-800 shadow-sm shadow-primary-200'>
       <div className='mb-4 flex justify-end'>
         <button className='justify-self-end' onClick={clearModal}>
@@ -19,7 +19,7 @@ export const DeleteModal: React.FC<DeleteModalPresenterProps> = ({
       </div>
       <div className='mx-auto px-8'>
         <div className='flex flex-col gap-y-4'>
-          <div className='text-lg'>{title}</div>
+          <div className='text-lg'>{toDo.title}</div>
           本当に削除しますか？
           <div className='mx-auto mb-4 flex flex-row gap-x-4'>
             <button className='btn green-gradient' onClick={descriptionClick}>

--- a/src/component/common/template/DeleteModal/DeleteModal.type.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.type.ts
@@ -1,0 +1,18 @@
+import { IconProps } from '../../part/Icon';
+
+export interface DeleteModalDataProps {
+  deleteDeepIcon: IconProps;
+  title: string;
+}
+
+export interface DeleteModalPresenterProps extends DeleteModalDataProps {
+  clearModal: () => void;
+}
+
+export interface DeleteModalContainerProps {
+  clearModal: () => void;
+}
+
+export interface DeleteModalLogicProps {
+  clearModal: () => void;
+}

--- a/src/component/common/template/DeleteModal/DeleteModal.type.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.type.ts
@@ -4,13 +4,13 @@ import { ToDoProps } from '@/hook/useTodos';
 
 export interface DeleteModalDataProps {
   deleteDeepIcon: IconProps;
-  title: string;
 }
 
 export interface DeleteModalPresenterProps extends DeleteModalDataProps {
   clearModal: () => void;
   descriptionClick: () => void;
   onDeleteClick: () => void;
+  toDo: ToDoProps;
 }
 
 export interface DeleteModalContainerProps {
@@ -19,10 +19,12 @@ export interface DeleteModalContainerProps {
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
   selectToDo: string;
+  toDo: ToDoProps;
 }
 
 export interface DeleteModalLogicProps {
   clearModal: () => void;
   descriptionClick: () => void;
   onDeleteClick: () => void;
+  toDo: ToDoProps;
 }

--- a/src/component/common/template/DeleteModal/DeleteModal.type.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.type.ts
@@ -1,4 +1,6 @@
+import { Dispatch, SetStateAction } from 'react';
 import { IconProps } from '../../part/Icon';
+import { ToDoProps } from '@/hook/useTodos';
 
 export interface DeleteModalDataProps {
   deleteDeepIcon: IconProps;
@@ -8,14 +10,19 @@ export interface DeleteModalDataProps {
 export interface DeleteModalPresenterProps extends DeleteModalDataProps {
   clearModal: () => void;
   descriptionClick: () => void;
+  onDeleteClick: () => void;
 }
 
 export interface DeleteModalContainerProps {
   clearModal: () => void;
   descriptionClick: () => void;
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  selectToDo: string;
 }
 
 export interface DeleteModalLogicProps {
   clearModal: () => void;
   descriptionClick: () => void;
+  onDeleteClick: () => void;
 }

--- a/src/component/common/template/DeleteModal/DeleteModal.type.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.type.ts
@@ -7,12 +7,15 @@ export interface DeleteModalDataProps {
 
 export interface DeleteModalPresenterProps extends DeleteModalDataProps {
   clearModal: () => void;
+  descriptionClick: () => void;
 }
 
 export interface DeleteModalContainerProps {
   clearModal: () => void;
+  descriptionClick: () => void;
 }
 
 export interface DeleteModalLogicProps {
   clearModal: () => void;
+  descriptionClick: () => void;
 }

--- a/src/component/common/template/DeleteModal/DeleteModal.type.ts
+++ b/src/component/common/template/DeleteModal/DeleteModal.type.ts
@@ -19,7 +19,6 @@ export interface DeleteModalContainerProps {
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
   selectToDo: string;
-  toDo: ToDoProps;
 }
 
 export interface DeleteModalLogicProps {

--- a/src/component/common/template/DeleteModal/index.tsx
+++ b/src/component/common/template/DeleteModal/index.tsx
@@ -13,6 +13,7 @@ const DeleteModal: React.FC<DeleteModalContainerProps> = ({
   toDos,
   setToDos,
   selectToDo,
+  toDo,
 }) => {
   const onDeleteClick = (): void => {
     const newToDos: ToDoProps[] = [...toDos];
@@ -23,6 +24,7 @@ const DeleteModal: React.FC<DeleteModalContainerProps> = ({
     clearModal: clearModal,
     descriptionClick: descriptionClick,
     onDeleteClick: onDeleteClick,
+    toDo: toDo,
   };
   const defaultProps: DeleteModalDataProps = { ...propObj.default };
   return <DeleteModalPresenter {...defaultProps} {...logicProps} />;

--- a/src/component/common/template/DeleteModal/index.tsx
+++ b/src/component/common/template/DeleteModal/index.tsx
@@ -13,13 +13,13 @@ const DeleteModal: React.FC<DeleteModalContainerProps> = ({
   toDos,
   setToDos,
   selectToDo,
-  toDo,
 }) => {
   const onDeleteClick = (): void => {
     const newToDos: ToDoProps[] = [...toDos];
     setToDos(newToDos.filter((v) => v !== newToDos[Number(selectToDo)]));
     clearModal();
   };
+  const toDo: ToDoProps = toDos[Number(selectToDo)];
   const logicProps: DeleteModalLogicProps = {
     clearModal: clearModal,
     descriptionClick: descriptionClick,

--- a/src/component/common/template/DeleteModal/index.tsx
+++ b/src/component/common/template/DeleteModal/index.tsx
@@ -5,11 +5,24 @@ import {
   DeleteModalDataProps,
   DeleteModalLogicProps,
 } from './DeleteModal.type';
+import { ToDoProps } from '@/hook/useTodos';
 
-const DeleteModal: React.FC<DeleteModalContainerProps> = ({ clearModal, descriptionClick }) => {
+const DeleteModal: React.FC<DeleteModalContainerProps> = ({
+  clearModal,
+  descriptionClick,
+  toDos,
+  setToDos,
+  selectToDo,
+}) => {
+  const onDeleteClick = (): void => {
+    const newToDos: ToDoProps[] = [...toDos];
+    setToDos(newToDos.filter((v) => v !== newToDos[Number(selectToDo)]));
+    clearModal();
+  };
   const logicProps: DeleteModalLogicProps = {
     clearModal: clearModal,
     descriptionClick: descriptionClick,
+    onDeleteClick: onDeleteClick,
   };
   const defaultProps: DeleteModalDataProps = { ...propObj.default };
   return <DeleteModalPresenter {...defaultProps} {...logicProps} />;

--- a/src/component/common/template/DeleteModal/index.tsx
+++ b/src/component/common/template/DeleteModal/index.tsx
@@ -6,9 +6,10 @@ import {
   DeleteModalLogicProps,
 } from './DeleteModal.type';
 
-const DeleteModal: React.FC<DeleteModalContainerProps> = ({ clearModal }) => {
+const DeleteModal: React.FC<DeleteModalContainerProps> = ({ clearModal, descriptionClick }) => {
   const logicProps: DeleteModalLogicProps = {
     clearModal: clearModal,
+    descriptionClick: descriptionClick,
   };
   const defaultProps: DeleteModalDataProps = { ...propObj.default };
   return <DeleteModalPresenter {...defaultProps} {...logicProps} />;

--- a/src/component/common/template/DeleteModal/index.tsx
+++ b/src/component/common/template/DeleteModal/index.tsx
@@ -1,18 +1,17 @@
-import { DeleteModal as DeleteModalPresenter, DeleteModalProps } from './DeleteModal';
+import { DeleteModal as DeleteModalPresenter } from './DeleteModal';
 import { propObj } from './DeleteModal.props';
+import {
+  DeleteModalContainerProps,
+  DeleteModalDataProps,
+  DeleteModalLogicProps,
+} from './DeleteModal.type';
 
-/**
- * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
- * 存在する場合はコメントアウト部分を全て削除して使ってください。
- */
-/* 
-export type { DeleteModalProps };
-export { DeleteModalPresenter};
-*/
-
-const DeleteModal: React.FC = () => {
-  const defaultProps: DeleteModalProps = { ...propObj.default };
-  return <DeleteModalPresenter {...defaultProps} />;
+const DeleteModal: React.FC<DeleteModalContainerProps> = ({ clearModal }) => {
+  const logicProps: DeleteModalLogicProps = {
+    clearModal: clearModal,
+  };
+  const defaultProps: DeleteModalDataProps = { ...propObj.default };
+  return <DeleteModalPresenter {...defaultProps} {...logicProps} />;
 };
 
 export { DeleteModal };

--- a/src/component/common/template/DescriptionModal/DescriptionModal.props.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.props.ts
@@ -1,12 +1,12 @@
 import { deleteDeepProps } from '../../part/Icon/Icon.props';
-import { DescriptionModalProps } from './DescriptionModal';
+import { DescriptionModalDataProps } from './DescriptionModal.type';
 
-const defaultProps: DescriptionModalProps = {
+const defaultProps: DescriptionModalDataProps = {
   deleteDeepIcon: deleteDeepProps,
   title: '経営の必読書を読む',
   description: ['イシューから始めよ', '起業のファイナンス', '起業の科学'],
 };
 
-export const propObj: { [key: string]: DescriptionModalProps } = {
+export const propObj: { [key: string]: DescriptionModalDataProps } = {
   default: defaultProps,
 };

--- a/src/component/common/template/DescriptionModal/DescriptionModal.props.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.props.ts
@@ -3,8 +3,6 @@ import { DescriptionModalDataProps } from './DescriptionModal.type';
 
 const defaultProps: DescriptionModalDataProps = {
   deleteDeepIcon: deleteDeepProps,
-  title: '経営の必読書を読む',
-  description: ['イシューから始めよ', '起業のファイナンス', '起業の科学'],
 };
 
 export const propObj: { [key: string]: DescriptionModalDataProps } = {

--- a/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
@@ -13,5 +13,5 @@ const Template: Story<DescriptionModalPresenterProps> = (args) => <DescriptionMo
 export const Default = Template.bind({});
 Default.args = {
   ...propObj.default,
-  toDo: { isCompleted: false, title: 'name', description: 'description' },
+  toDo: { isCompleted: false, title: '経営の必読書を読む', description: 'イシューから始めよ' },
 };

--- a/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
@@ -1,6 +1,7 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { DescriptionModal, DescriptionModalProps } from './DescriptionModal';
 import { propObj } from './DescriptionModal.props';
+import { DescriptionModalProps } from './DescriptionModal.type';
+import { DescriptionModal } from './index';
 
 export default {
   title: 'Common/template/DescriptionModal',

--- a/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
@@ -13,5 +13,10 @@ const Template: Story<DescriptionModalPresenterProps> = (args) => <DescriptionMo
 export const Default = Template.bind({});
 Default.args = {
   ...propObj.default,
-  toDo: { isCompleted: false, title: '経営の必読書を読む', description: 'イシューから始めよ' },
+  toDo: {
+    isCompleted: false,
+    title: '経営の必読書を読む',
+    description: 'イシューから始めよ',
+    id: -1,
+  },
 };

--- a/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.stories.tsx
@@ -1,14 +1,17 @@
 import type { ComponentMeta, Story } from '@storybook/react';
+import { DescriptionModal } from './DescriptionModal';
 import { propObj } from './DescriptionModal.props';
-import { DescriptionModalProps } from './DescriptionModal.type';
-import { DescriptionModal } from './index';
+import { DescriptionModalPresenterProps } from './DescriptionModal.type';
 
 export default {
   title: 'Common/template/DescriptionModal',
   component: DescriptionModal,
 } as ComponentMeta<typeof DescriptionModal>;
 
-const Template: Story<DescriptionModalProps> = (args) => <DescriptionModal {...args} />;
+const Template: Story<DescriptionModalPresenterProps> = (args) => <DescriptionModal {...args} />;
 
 export const Default = Template.bind({});
-Default.args = propObj.default;
+Default.args = {
+  ...propObj.default,
+  toDo: { isCompleted: false, title: 'name', description: 'description' },
+};

--- a/src/component/common/template/DescriptionModal/DescriptionModal.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.tsx
@@ -6,6 +6,7 @@ export const baseId = 'common-template-description-modal';
 export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
   deleteDeepIcon,
   updateSetClick,
+  deleteSetClick,
   clearModal,
   toDo,
 }) => (
@@ -20,9 +21,12 @@ export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
         <div className='flex flex-col gap-y-4'>
           <div className='text-lg'>{toDo.title}</div>
           <div>{toDo.description}</div>
-          <div className='text-right'>
+          <div className='flex flex-row justify-end gap-x-2'>
             <button className='btn green-gradient' onClick={updateSetClick}>
               更新
+            </button>
+            <button className='btn pink-gradient' onClick={deleteSetClick}>
+              削除
             </button>
           </div>
         </div>

--- a/src/component/common/template/DescriptionModal/DescriptionModal.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.tsx
@@ -5,8 +5,6 @@ export const baseId = 'common-template-description-modal';
 
 export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
   deleteDeepIcon,
-  title,
-  description,
   clearModal,
   toDo,
 }) => (
@@ -19,13 +17,7 @@ export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
       </div>
       <div className='mx-auto px-8'>
         <div className='flex flex-col gap-y-4'>
-          <div className='text-lg'>{title}</div>
-          <ul>
-            {description.map((item, i) => (
-              <li key={i}>・{item}</li>
-            ))}
-          </ul>
-          <div>{toDo.title}</div>
+          <div className='text-lg'>{toDo.title}</div>
           <div>{toDo.description}</div>
           <div className='text-right'>
             <button className='btn green-gradient'>更新</button>

--- a/src/component/common/template/DescriptionModal/DescriptionModal.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.tsx
@@ -5,6 +5,7 @@ export const baseId = 'common-template-description-modal';
 
 export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
   deleteDeepIcon,
+  updateClick,
   clearModal,
   toDo,
 }) => (
@@ -20,7 +21,9 @@ export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
           <div className='text-lg'>{toDo.title}</div>
           <div>{toDo.description}</div>
           <div className='text-right'>
-            <button className='btn green-gradient'>更新</button>
+            <button className='btn green-gradient' onClick={updateClick}>
+              更新
+            </button>
           </div>
         </div>
       </div>

--- a/src/component/common/template/DescriptionModal/DescriptionModal.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.tsx
@@ -5,7 +5,7 @@ export const baseId = 'common-template-description-modal';
 
 export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
   deleteDeepIcon,
-  updateClick,
+  updateSetClick,
   clearModal,
   toDo,
 }) => (
@@ -21,7 +21,7 @@ export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
           <div className='text-lg'>{toDo.title}</div>
           <div>{toDo.description}</div>
           <div className='text-right'>
-            <button className='btn green-gradient' onClick={updateClick}>
+            <button className='btn green-gradient' onClick={updateSetClick}>
               更新
             </button>
           </div>

--- a/src/component/common/template/DescriptionModal/DescriptionModal.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.tsx
@@ -1,15 +1,9 @@
-import { Icon, IconProps } from '../../part/Icon';
-
-export interface DescriptionModalProps {
-  deleteDeepIcon: IconProps;
-  title: string;
-  description: string[];
-  clearModal?: () => void;
-}
+import { Icon } from '../../part/Icon';
+import { DescriptionModalPresenterProps } from './DescriptionModal.type';
 
 export const baseId = 'common-template-description-modal';
 
-export const DescriptionModal: React.FC<DescriptionModalProps> = ({
+export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
   deleteDeepIcon,
   title,
   description,

--- a/src/component/common/template/DescriptionModal/DescriptionModal.tsx
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.tsx
@@ -8,6 +8,7 @@ export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
   title,
   description,
   clearModal,
+  toDo,
 }) => (
   <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50/90'>
     <div className='w-80 bg-white p-4 font-bold text-primary-800 shadow-sm shadow-primary-200'>
@@ -24,6 +25,8 @@ export const DescriptionModal: React.FC<DescriptionModalPresenterProps> = ({
               <li key={i}>・{item}</li>
             ))}
           </ul>
+          <div>{toDo.title}</div>
+          <div>{toDo.description}</div>
           <div className='text-right'>
             <button className='btn green-gradient'>更新</button>
           </div>

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -8,14 +8,14 @@ export interface DescriptionModalDataProps {
 //Dataに含まれないロジック要素を追加
 export interface DescriptionModalPresenterProps extends DescriptionModalDataProps {
   clearModal: () => void;
-  updateClick: () => void;
+  updateSetClick: () => void;
   toDo: ToDoProps;
 }
 
 // 親コンポーネントから受継ぐロジック要素
 export interface DescriptionModalContainerProps {
   clearModal: () => void;
-  updateClick: () => void;
+  updateSetClick: () => void;
   toDo: ToDoProps;
 }
 
@@ -24,6 +24,6 @@ export interface DescriptionModalContainerProps {
 //Container内部で新たに生じたLogicの型定義
 export interface DescriptionModalLogicProps {
   clearModal: () => void;
-  updateClick: () => void;
+  updateSetClick: () => void;
   toDo: ToDoProps;
 }

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -1,0 +1,27 @@
+import { IconProps } from '../../part/Icon';
+import { ToDoProps } from '@/hook/useTodos';
+
+export interface DescriptionModalDataProps {
+  deleteDeepIcon: IconProps;
+  title: string;
+  description: string[];
+}
+
+//Dataに含まれないロジック要素を追加
+export interface DescriptionModalPresenterProps extends DescriptionModalDataProps {
+  clearModal: () => void;
+}
+
+// 親コンポーネントから受継ぐロジック要素
+export interface DescriptionModalContainerProps {
+  clearModal: () => void;
+  toDo: ToDoProps;
+}
+
+//Storybook用のすべてを含んだ型
+export interface DescriptionModalProps extends DescriptionModalPresenterProps {
+  toDo: ToDoProps;
+}
+
+//Container内部で新たに生じたLogicの型定義
+// export interface DescriptionModalLogicProps {}

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -9,6 +9,7 @@ export interface DescriptionModalDataProps {
 export interface DescriptionModalPresenterProps extends DescriptionModalDataProps {
   clearModal: () => void;
   updateSetClick: () => void;
+  deleteSetClick: () => void;
   toDo: ToDoProps;
 }
 
@@ -16,6 +17,7 @@ export interface DescriptionModalPresenterProps extends DescriptionModalDataProp
 export interface DescriptionModalContainerProps {
   clearModal: () => void;
   updateSetClick: () => void;
+  deleteSetClick: () => void;
   toDo: ToDoProps;
 }
 
@@ -25,5 +27,6 @@ export interface DescriptionModalContainerProps {
 export interface DescriptionModalLogicProps {
   clearModal: () => void;
   updateSetClick: () => void;
+  deleteSetClick: () => void;
   toDo: ToDoProps;
 }

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -8,12 +8,14 @@ export interface DescriptionModalDataProps {
 //Dataに含まれないロジック要素を追加
 export interface DescriptionModalPresenterProps extends DescriptionModalDataProps {
   clearModal: () => void;
+  updateClick: () => void;
   toDo: ToDoProps;
 }
 
 // 親コンポーネントから受継ぐロジック要素
 export interface DescriptionModalContainerProps {
   clearModal: () => void;
+  updateClick: () => void;
   toDo: ToDoProps;
 }
 
@@ -22,5 +24,6 @@ export interface DescriptionModalContainerProps {
 //Container内部で新たに生じたLogicの型定義
 export interface DescriptionModalLogicProps {
   clearModal: () => void;
+  updateClick: () => void;
   toDo: ToDoProps;
 }

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -10,6 +10,7 @@ export interface DescriptionModalDataProps {
 //Dataに含まれないロジック要素を追加
 export interface DescriptionModalPresenterProps extends DescriptionModalDataProps {
   clearModal: () => void;
+  toDo: ToDoProps;
 }
 
 // 親コンポーネントから受継ぐロジック要素
@@ -19,7 +20,8 @@ export interface DescriptionModalContainerProps {
 }
 
 //Storybook用のすべてを含んだ型
-export interface DescriptionModalProps extends DescriptionModalPresenterProps {
+export interface DescriptionModalProps extends DescriptionModalDataProps {
+  clearModal: () => void;
   toDo: ToDoProps;
 }
 

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -19,11 +19,7 @@ export interface DescriptionModalContainerProps {
   toDo: ToDoProps;
 }
 
-//Storybook用のすべてを含んだ型
-export interface DescriptionModalProps extends DescriptionModalDataProps {
-  clearModal: () => void;
-  toDo: ToDoProps;
-}
+//Storybook用のすべてを含んだ型→不要
 
 //Container内部で新たに生じたLogicの型定義
 export interface DescriptionModalLogicProps {

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -3,8 +3,6 @@ import { ToDoProps } from '@/hook/useTodos';
 
 export interface DescriptionModalDataProps {
   deleteDeepIcon: IconProps;
-  title: string;
-  description: string[];
 }
 
 //Dataに含まれないロジック要素を追加

--- a/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
+++ b/src/component/common/template/DescriptionModal/DescriptionModal.type.ts
@@ -24,4 +24,7 @@ export interface DescriptionModalProps extends DescriptionModalPresenterProps {
 }
 
 //Container内部で新たに生じたLogicの型定義
-// export interface DescriptionModalLogicProps {}
+export interface DescriptionModalLogicProps {
+  clearModal: () => void;
+  toDo: ToDoProps;
+}

--- a/src/component/common/template/DescriptionModal/index.tsx
+++ b/src/component/common/template/DescriptionModal/index.tsx
@@ -17,12 +17,14 @@ export { DescriptionModalPresenter};
 
 const DescriptionModal: React.FC<DescriptionModalContainerProps> = ({
   updateSetClick,
+  deleteSetClick,
   clearModal,
   toDo,
 }) => {
   const logicProps: DescriptionModalLogicProps = {
     clearModal: clearModal,
     updateSetClick: updateSetClick,
+    deleteSetClick: deleteSetClick,
     toDo: toDo,
   };
   const defaultProps: DescriptionModalDataProps = { ...propObj.default };

--- a/src/component/common/template/DescriptionModal/index.tsx
+++ b/src/component/common/template/DescriptionModal/index.tsx
@@ -15,9 +15,14 @@ export type { DescriptionModalDataProps };
 export { DescriptionModalPresenter};
 */
 
-const DescriptionModal: React.FC<DescriptionModalContainerProps> = ({ clearModal, toDo }) => {
+const DescriptionModal: React.FC<DescriptionModalContainerProps> = ({
+  updateClick,
+  clearModal,
+  toDo,
+}) => {
   const logicProps: DescriptionModalLogicProps = {
     clearModal: clearModal,
+    updateClick: updateClick,
     toDo: toDo,
   };
   const defaultProps: DescriptionModalDataProps = { ...propObj.default };

--- a/src/component/common/template/DescriptionModal/index.tsx
+++ b/src/component/common/template/DescriptionModal/index.tsx
@@ -1,21 +1,18 @@
-import {
-  DescriptionModal as DescriptionModalPresenter,
-  DescriptionModalProps,
-} from './DescriptionModal';
-
+import { DescriptionModal as DescriptionModalPresenter } from './DescriptionModal';
 import { propObj } from './DescriptionModal.props';
+import { DescriptionModalDataProps } from './DescriptionModal.type';
 
 /**
  * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
  * 存在する場合はコメントアウト部分を全て削除して使ってください。
  */
 /* 
-export type { DescriptionModalProps };
+export type { DescriptionModalDataProps };
 export { DescriptionModalPresenter};
 */
 
 const DescriptionModal: React.FC = () => {
-  const defaultProps: DescriptionModalProps = { ...propObj.default };
+  const defaultProps: DescriptionModalDataProps = { ...propObj.default };
   return <DescriptionModalPresenter {...defaultProps} />;
 };
 

--- a/src/component/common/template/DescriptionModal/index.tsx
+++ b/src/component/common/template/DescriptionModal/index.tsx
@@ -16,13 +16,13 @@ export { DescriptionModalPresenter};
 */
 
 const DescriptionModal: React.FC<DescriptionModalContainerProps> = ({
-  updateClick,
+  updateSetClick,
   clearModal,
   toDo,
 }) => {
   const logicProps: DescriptionModalLogicProps = {
     clearModal: clearModal,
-    updateClick: updateClick,
+    updateSetClick: updateSetClick,
     toDo: toDo,
   };
   const defaultProps: DescriptionModalDataProps = { ...propObj.default };

--- a/src/component/common/template/DescriptionModal/index.tsx
+++ b/src/component/common/template/DescriptionModal/index.tsx
@@ -1,6 +1,10 @@
 import { DescriptionModal as DescriptionModalPresenter } from './DescriptionModal';
 import { propObj } from './DescriptionModal.props';
-import { DescriptionModalDataProps } from './DescriptionModal.type';
+import {
+  DescriptionModalContainerProps,
+  DescriptionModalDataProps,
+  DescriptionModalLogicProps,
+} from './DescriptionModal.type';
 
 /**
  * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
@@ -11,9 +15,13 @@ export type { DescriptionModalDataProps };
 export { DescriptionModalPresenter};
 */
 
-const DescriptionModal: React.FC = () => {
+const DescriptionModal: React.FC<DescriptionModalContainerProps> = ({ clearModal, toDo }) => {
+  const logicProps: DescriptionModalLogicProps = {
+    clearModal: clearModal,
+    toDo: toDo,
+  };
   const defaultProps: DescriptionModalDataProps = { ...propObj.default };
-  return <DescriptionModalPresenter {...defaultProps} />;
+  return <DescriptionModalPresenter {...defaultProps} {...logicProps} />;
 };
 
 export { DescriptionModal };

--- a/src/component/common/template/InputModal/InputModal.props.ts
+++ b/src/component/common/template/InputModal/InputModal.props.ts
@@ -1,17 +1,17 @@
 import { deleteDeepProps } from '../../part/Icon/Icon.props';
-import { InputModalProps } from './InputModal';
+import { InputModalDataProps } from '@/component/common/template/InputModal/InputModal.type';
 
-const defaultProps: InputModalProps = {
+const defaultProps: InputModalDataProps = {
   type: 'create',
   deleteDeepIcon: deleteDeepProps,
 };
 
-const updateProps: InputModalProps = {
+const updateProps: InputModalDataProps = {
   type: 'update',
   deleteDeepIcon: deleteDeepProps,
 };
 
-export const propObj: { [key: string]: InputModalProps } = {
+export const propObj: { [key: string]: InputModalDataProps } = {
   default: defaultProps,
   update: updateProps,
 };

--- a/src/component/common/template/InputModal/InputModal.props.ts
+++ b/src/component/common/template/InputModal/InputModal.props.ts
@@ -2,12 +2,10 @@ import { deleteDeepProps } from '../../part/Icon/Icon.props';
 import { InputModalDataProps } from '@/component/common/template/InputModal/InputModal.type';
 
 const defaultProps: InputModalDataProps = {
-  type: 'create',
   deleteDeepIcon: deleteDeepProps,
 };
 
 const updateProps: InputModalDataProps = {
-  type: 'update',
   deleteDeepIcon: deleteDeepProps,
 };
 

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -14,7 +14,7 @@ export const Default = Template.bind({});
 Default.args = {
   type: 'create',
   ...propObj.default,
-  formState: { title: '', description: '', isCompleted: false },
+  formState: { title: '', description: '', isCompleted: false, id: -1 },
 };
 export const Update = Template.bind({});
 Update.args = { type: 'update', ...propObj.update };

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -1,14 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { InputModal } from './InputModal';
 import { propObj } from './InputModal.props';
-import { InputModalPresenterProps } from './InputModal.type';
+import { InputModalProps } from './InputModal.type';
+import { InputModal } from './index';
 
 export default {
   title: 'Common/template/InputModal',
   component: InputModal,
 } as ComponentMeta<typeof InputModal>;
 
-const Template: Story<InputModalPresenterProps> = (args) => <InputModal {...args} />;
+const Template: Story<InputModalProps> = (args) => <InputModal {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { InputModal, InputModalProps } from './InputModal';
+import { InputModal, InputModalFcProps } from './InputModal';
 import { propObj } from './InputModal.props';
 
 export default {
@@ -7,7 +7,7 @@ export default {
   component: InputModal,
 } as ComponentMeta<typeof InputModal>;
 
-const Template: Story<InputModalProps> = (args) => <InputModal {...args} />;
+const Template: Story<InputModalFcProps> = (args) => <InputModal {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -1,13 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { InputModal, InputModalFcProps } from './InputModal';
+import { InputModal } from './InputModal';
 import { propObj } from './InputModal.props';
+import { InputModalPresenterProps } from './InputModal.type';
 
 export default {
   title: 'Common/template/InputModal',
   component: InputModal,
 } as ComponentMeta<typeof InputModal>;
 
-const Template: Story<InputModalFcProps> = (args) => <InputModal {...args} />;
+const Template: Story<InputModalPresenterProps> = (args) => <InputModal {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -1,16 +1,19 @@
 import type { ComponentMeta, Story } from '@storybook/react';
+import { InputModal } from './InputModal';
 import { propObj } from './InputModal.props';
-import { InputModalProps } from './InputModal.type';
-import { InputModal } from './index';
+import { InputModalPresenterProps } from './InputModal.type';
 
 export default {
   title: 'Common/template/InputModal',
   component: InputModal,
 } as ComponentMeta<typeof InputModal>;
 
-const Template: Story<InputModalProps> = (args) => <InputModal {...args} />;
+const Template: Story<InputModalPresenterProps> = (args) => <InputModal {...args} />;
 
 export const Default = Template.bind({});
-Default.args = propObj.default;
+Default.args = {
+  ...propObj.default,
+  formState: { title: '', description: '', isCompleted: false },
+};
 export const Update = Template.bind({});
 Update.args = propObj.update;

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -17,4 +17,8 @@ Default.args = {
   formState: { title: '', description: '', isCompleted: false, id: -1 },
 };
 export const Update = Template.bind({});
-Update.args = { type: 'update', ...propObj.update };
+Update.args = {
+  type: 'update',
+  ...propObj.update,
+  formState: { title: '', description: '', isCompleted: false, id: -1 },
+};

--- a/src/component/common/template/InputModal/InputModal.stories.tsx
+++ b/src/component/common/template/InputModal/InputModal.stories.tsx
@@ -12,8 +12,9 @@ const Template: Story<InputModalPresenterProps> = (args) => <InputModal {...args
 
 export const Default = Template.bind({});
 Default.args = {
+  type: 'create',
   ...propObj.default,
   formState: { title: '', description: '', isCompleted: false },
 };
 export const Update = Template.bind({});
-Update.args = propObj.update;
+Update.args = { type: 'update', ...propObj.update };

--- a/src/component/common/template/InputModal/InputModal.tsx
+++ b/src/component/common/template/InputModal/InputModal.tsx
@@ -9,6 +9,7 @@ export const InputModal: React.FC<InputModalPresenterProps> = ({
   clearModal,
   onClearModal,
   onCreateClick,
+  onUpdateClick,
   handleInput,
   formState,
 }) => {
@@ -76,7 +77,7 @@ export const InputModal: React.FC<InputModalPresenterProps> = ({
                   />
                 </form>
                 <div className='text-right'>
-                  <button className='btn green-gradient' onClick={onCreateClick}>
+                  <button className='btn green-gradient' onClick={onUpdateClick}>
                     更新
                   </button>
                 </div>

--- a/src/component/common/template/InputModal/InputModal.tsx
+++ b/src/component/common/template/InputModal/InputModal.tsx
@@ -60,8 +60,21 @@ export const InputModal: React.FC<InputModalPresenterProps> = ({
             </div>
             <div className='mx-auto px-8'>
               <div className='flex flex-col gap-y-4'>
-                <div className='text-lg'>タイトル</div>
-                内容
+                <form className='flex flex-col gap-y-1'>
+                  <label className='text-lg'>タイトル</label>
+                  <input
+                    className='form'
+                    type='text'
+                    onChange={(e) => handleInput('title', e.target.value)}
+                    value={formState.title}
+                  />
+                  <label>内容</label>
+                  <textarea
+                    className='textarea'
+                    onChange={(e) => handleInput('description', e.target.value)}
+                    value={formState.description}
+                  />
+                </form>
                 <div className='text-right'>
                   <button className='btn green-gradient' onClick={onCreateClick}>
                     更新

--- a/src/component/common/template/InputModal/InputModal.tsx
+++ b/src/component/common/template/InputModal/InputModal.tsx
@@ -1,5 +1,7 @@
+import { Dispatch, SetStateAction } from 'react';
 import { Icon, IconProps } from '../../part/Icon';
 import { useFormState } from '@/hook/useFormState';
+import { ToDoProps } from '@/hook/useTodos';
 
 export interface InputModalProps {
   type: 'create' | 'update';
@@ -8,7 +10,8 @@ export interface InputModalProps {
 
 export interface InputModalFcProps extends InputModalProps {
   clearModal: () => void;
-  handleClick: () => void;
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
 export const baseId = 'common-template-input-modal';
@@ -17,20 +20,27 @@ export const InputModal: React.FC<InputModalFcProps> = ({
   type,
   deleteDeepIcon,
   clearModal,
-  handleClick,
+  toDos,
+  setToDos,
 }) => {
   // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
   // PageMainでformStateの管理をすると、InputModalにバケツリレーするが、その際にInputModalPropsでhandleInput?:とオプショナルを指定すると、undefinedとなりInputModal.propsの中身と齟齬が生じる
   // 結果としてInputModalで状態管理をすることとした。
   const { formState, handleInput } = useFormState();
-
+  const onClearModal = (): void => clearModal();
+  const onCreateClick = (): void => {
+    const newToDos = [...toDos];
+    setToDos([...newToDos, { ...formState }]);
+    clearModal();
+  };
+  // 関数をpropsで親要素から子要素に受け継ぐ場合には子要素であらためて関数を定義する必要がある！
   switch (type) {
     case 'create':
       return (
         <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center bg-primary-50/90 '>
           <div className='w-80 bg-white p-4 font-bold text-primary-800 shadow-sm shadow-primary-200'>
             <div className='mb-4 flex justify-end'>
-              <button className='justify-self-end' onClick={clearModal}>
+              <button className='justify-self-end' onClick={onClearModal}>
                 <Icon {...deleteDeepIcon} />
               </button>
             </div>
@@ -53,7 +63,7 @@ export const InputModal: React.FC<InputModalFcProps> = ({
                   />
                 </form>
                 <div className='text-right'>
-                  <button className='btn green-gradient' onClick={handleClick}>
+                  <button className='btn green-gradient' onClick={onCreateClick}>
                     新規追加
                   </button>
                 </div>
@@ -76,7 +86,7 @@ export const InputModal: React.FC<InputModalFcProps> = ({
                 <div className='text-lg'>タイトル</div>
                 内容
                 <div className='text-right'>
-                  <button className='btn green-gradient' onClick={handleClick}>
+                  <button className='btn green-gradient' onClick={onCreateClick}>
                     更新
                   </button>
                 </div>

--- a/src/component/common/template/InputModal/InputModal.tsx
+++ b/src/component/common/template/InputModal/InputModal.tsx
@@ -1,39 +1,17 @@
-import { Dispatch, SetStateAction } from 'react';
-import { Icon, IconProps } from '../../part/Icon';
-import { useFormState } from '@/hook/useFormState';
-import { ToDoProps } from '@/hook/useTodos';
-
-export interface InputModalProps {
-  type: 'create' | 'update';
-  deleteDeepIcon: IconProps;
-}
-
-export interface InputModalFcProps extends InputModalProps {
-  clearModal: () => void;
-  toDos: ToDoProps[];
-  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-}
+import { Icon } from '../../part/Icon';
+import { InputModalPresenterProps } from '@/component/common/template/InputModal/InputModal.type';
 
 export const baseId = 'common-template-input-modal';
 
-export const InputModal: React.FC<InputModalFcProps> = ({
+export const InputModal: React.FC<InputModalPresenterProps> = ({
   type,
   deleteDeepIcon,
   clearModal,
-  toDos,
-  setToDos,
+  onClearModal,
+  onCreateClick,
+  handleInput,
+  formState,
 }) => {
-  // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
-  // PageMainでformStateの管理をすると、InputModalにバケツリレーするが、その際にInputModalPropsでhandleInput?:とオプショナルを指定すると、undefinedとなりInputModal.propsの中身と齟齬が生じる
-  // 結果としてInputModalで状態管理をすることとした。
-  const { formState, handleInput } = useFormState();
-  const onClearModal = (): void => clearModal();
-  const onCreateClick = (): void => {
-    const newToDos = [...toDos];
-    setToDos([...newToDos, { ...formState }]);
-    clearModal();
-  };
-  // 関数をpropsで親要素から子要素に受け継ぐ場合には子要素であらためて関数を定義する必要がある！
   switch (type) {
     case 'create':
       return (
@@ -52,14 +30,13 @@ export const InputModal: React.FC<InputModalFcProps> = ({
                     className='form'
                     type='text'
                     onChange={(e) => handleInput('title', e.target.value)}
-                    value={formState?.title}
+                    value={formState.title}
                   />
                   <label>内容</label>
-                  <input
-                    className='form'
-                    type='text'
+                  <textarea
+                    className='textarea'
                     onChange={(e) => handleInput('description', e.target.value)}
-                    value={formState?.description}
+                    value={formState.description}
                   />
                 </form>
                 <div className='text-right'>

--- a/src/component/common/template/InputModal/InputModal.tsx
+++ b/src/component/common/template/InputModal/InputModal.tsx
@@ -4,24 +4,26 @@ import { useFormState } from '@/hook/useFormState';
 export interface InputModalProps {
   type: 'create' | 'update';
   deleteDeepIcon: IconProps;
-  clearModal?: () => void;
-  addClick?: () => void;
-  modifyClick?: () => void;
+}
+
+export interface InputModalFcProps extends InputModalProps {
+  clearModal: () => void;
+  handleClick: () => void;
 }
 
 export const baseId = 'common-template-input-modal';
 
-export const InputModal: React.FC<InputModalProps> = ({
+export const InputModal: React.FC<InputModalFcProps> = ({
   type,
   deleteDeepIcon,
   clearModal,
-  addClick,
-  modifyClick,
+  handleClick,
 }) => {
   // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
   // PageMainでformStateの管理をすると、InputModalにバケツリレーするが、その際にInputModalPropsでhandleInput?:とオプショナルを指定すると、undefinedとなりInputModal.propsの中身と齟齬が生じる
   // 結果としてInputModalで状態管理をすることとした。
   const { formState, handleInput } = useFormState();
+
   switch (type) {
     case 'create':
       return (
@@ -51,7 +53,7 @@ export const InputModal: React.FC<InputModalProps> = ({
                   />
                 </form>
                 <div className='text-right'>
-                  <button className='btn green-gradient' onClick={addClick}>
+                  <button className='btn green-gradient' onClick={handleClick}>
                     新規追加
                   </button>
                 </div>
@@ -74,7 +76,7 @@ export const InputModal: React.FC<InputModalProps> = ({
                 <div className='text-lg'>タイトル</div>
                 内容
                 <div className='text-right'>
-                  <button className='btn green-gradient' onClick={modifyClick}>
+                  <button className='btn green-gradient' onClick={handleClick}>
                     更新
                   </button>
                 </div>

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -23,6 +23,12 @@ export interface InputModalContainerProps {
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
+//Storybook用のすべてを含んだ型
+export interface InputModalProps extends InputModalPresenterProps {
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+}
+
 //Container内部で新たに生じたLogicの型定義
 export interface InputModalLogicProps {
   clearModal: () => void;

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -12,6 +12,7 @@ export interface InputModalPresenterProps extends InputModalDataProps {
   clearModal: () => void;
   onClearModal: () => void;
   onCreateClick: () => void;
+  onUpdateClick: () => void;
   formState: ToDoProps;
   handleInput: (key: string, value: string) => void;
 }
@@ -23,6 +24,7 @@ export interface InputModalContainerProps {
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
   onCreateClick: () => void;
+  onUpdateClick: () => void;
   formState: ToDoProps;
   handleInput: (key: string, value: string) => void;
 }
@@ -35,6 +37,7 @@ export interface InputModalLogicProps {
   clearModal: () => void;
   onClearModal: () => void;
   onCreateClick: () => void;
+  onUpdateClick: () => void;
   handleInput: (key: string, value: string) => void;
   formState: ToDoProps;
   toDos: ToDoProps[];

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -7,9 +7,8 @@ export interface InputModalDataProps {
   deleteDeepIcon: IconProps;
 }
 
-export interface InputModalPresenterProps {
-  type: 'create' | 'update';
-  deleteDeepIcon: IconProps;
+//Dataに含まれないロジック要素を追加
+export interface InputModalPresenterProps extends InputModalDataProps {
   clearModal: () => void;
   onClearModal: () => void;
   onCreateClick: () => void;
@@ -17,11 +16,14 @@ export interface InputModalPresenterProps {
   formState: ToDoProps;
 }
 
-export interface InputModalContainerProps extends InputModalPresenterProps {
+// 親コンポーネントから受継ぐロジック要素
+export interface InputModalContainerProps {
+  clearModal: () => void;
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
+//Container内部で新たに生じたLogicの型定義
 export interface InputModalLogicProps {
   clearModal: () => void;
   onClearModal: () => void;
@@ -30,11 +32,4 @@ export interface InputModalLogicProps {
   formState: ToDoProps;
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-}
-
-export interface InputModalLogic2Props {
-  onClearModal: () => void;
-  onCreateClick: () => void;
-  handleInput: (key: string, value: string) => void;
-  formState: ToDoProps;
 }

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -1,0 +1,40 @@
+import { Dispatch, SetStateAction } from 'react';
+import { IconProps } from '../../part/Icon';
+import { ToDoProps } from '@/hook/useTodos';
+
+export interface InputModalDataProps {
+  type: 'create' | 'update';
+  deleteDeepIcon: IconProps;
+}
+
+export interface InputModalPresenterProps {
+  type: 'create' | 'update';
+  deleteDeepIcon: IconProps;
+  clearModal: () => void;
+  onClearModal: () => void;
+  onCreateClick: () => void;
+  handleInput: (key: string, value: string) => void;
+  formState: ToDoProps;
+}
+
+export interface InputModalContainerProps extends InputModalPresenterProps {
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+}
+
+export interface InputModalLogicProps {
+  clearModal: () => void;
+  onClearModal: () => void;
+  onCreateClick: () => void;
+  handleInput: (key: string, value: string) => void;
+  formState: ToDoProps;
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+}
+
+export interface InputModalLogic2Props {
+  onClearModal: () => void;
+  onCreateClick: () => void;
+  handleInput: (key: string, value: string) => void;
+  formState: ToDoProps;
+}

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -23,11 +23,7 @@ export interface InputModalContainerProps {
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
-//Storybook用のすべてを含んだ型
-export interface InputModalProps extends InputModalPresenterProps {
-  toDos: ToDoProps[];
-  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-}
+//Storybook用のすべてを含んだ型→不要PresenterPropsでOK
 
 //Container内部で新たに生じたLogicの型定義
 export interface InputModalLogicProps {

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -12,8 +12,8 @@ export interface InputModalPresenterProps extends InputModalDataProps {
   clearModal: () => void;
   onClearModal: () => void;
   onCreateClick: () => void;
-  handleInput: (key: string, value: string) => void;
   formState: ToDoProps;
+  handleInput: (key: string, value: string) => void;
 }
 
 // 親コンポーネントから受継ぐロジック要素
@@ -22,6 +22,9 @@ export interface InputModalContainerProps {
   clearModal: () => void;
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  onCreateClick: () => void;
+  formState: ToDoProps;
+  handleInput: (key: string, value: string) => void;
 }
 
 //Storybook用のすべてを含んだ型→不要PresenterPropsでOK

--- a/src/component/common/template/InputModal/InputModal.type.ts
+++ b/src/component/common/template/InputModal/InputModal.type.ts
@@ -3,12 +3,12 @@ import { IconProps } from '../../part/Icon';
 import { ToDoProps } from '@/hook/useTodos';
 
 export interface InputModalDataProps {
-  type: 'create' | 'update';
   deleteDeepIcon: IconProps;
 }
 
 //Dataに含まれないロジック要素を追加
 export interface InputModalPresenterProps extends InputModalDataProps {
+  type: 'create' | 'update';
   clearModal: () => void;
   onClearModal: () => void;
   onCreateClick: () => void;
@@ -18,6 +18,7 @@ export interface InputModalPresenterProps extends InputModalDataProps {
 
 // 親コンポーネントから受継ぐロジック要素
 export interface InputModalContainerProps {
+  type: 'create' | 'update';
   clearModal: () => void;
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
@@ -27,6 +28,7 @@ export interface InputModalContainerProps {
 
 //Container内部で新たに生じたLogicの型定義
 export interface InputModalLogicProps {
+  type: 'create' | 'update';
   clearModal: () => void;
   onClearModal: () => void;
   onCreateClick: () => void;

--- a/src/component/common/template/InputModal/index.tsx
+++ b/src/component/common/template/InputModal/index.tsx
@@ -13,6 +13,7 @@ const InputModal: React.FC<InputModalContainerProps> = ({
   setToDos,
   formState,
   onCreateClick,
+  onUpdateClick,
   handleInput,
 }) => {
   // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
@@ -27,6 +28,7 @@ const InputModal: React.FC<InputModalContainerProps> = ({
     handleInput: handleInput,
     clearModal: clearModal,
     onClearModal: onClearModal,
+    onUpdateClick: onUpdateClick,
     onCreateClick: onCreateClick,
     formState: formState,
     toDos: toDos,

--- a/src/component/common/template/InputModal/index.tsx
+++ b/src/component/common/template/InputModal/index.tsx
@@ -7,7 +7,7 @@ import {
 } from './InputModal.type';
 import { useFormState } from '@/hook/useFormState';
 
-const InputModal: React.FC<InputModalContainerProps> = ({ clearModal, toDos, setToDos }) => {
+const InputModal: React.FC<InputModalContainerProps> = ({ type, clearModal, toDos, setToDos }) => {
   // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
   // PageMainでformStateの管理をすると、InputModalにバケツリレーするが、その際にInputModalPropsでhandleInput?:とオプショナルを指定すると、undefinedとなりInputModal.propsの中身と齟齬が生じる
   // 結果としてInputModalで状態管理をすることとした。
@@ -20,6 +20,7 @@ const InputModal: React.FC<InputModalContainerProps> = ({ clearModal, toDos, set
   };
   // 関数をpropsで親要素から子要素に受け継ぐ場合には子要素であらためて関数を定義する必要がある！
   const logicProps: InputModalLogicProps = {
+    type: type,
     handleInput: handleInput,
     clearModal: clearModal,
     onClearModal: onClearModal,

--- a/src/component/common/template/InputModal/index.tsx
+++ b/src/component/common/template/InputModal/index.tsx
@@ -1,17 +1,35 @@
-import { InputModal as InputModalPresenter, InputModalProps } from './InputModal';
+import { InputModal as InputModalPresenter } from './InputModal';
 import { propObj } from './InputModal.props';
-/**
- * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
- * 存在する場合はコメントアウト部分を全て削除して使ってください。
- */
-/* 
-export type { InputModalProps };
-export { InputModalPresenter};
-*/
+import {
+  InputModalContainerProps,
+  InputModalLogicProps,
+  InputModalDataProps,
+} from './InputModal.type';
+import { useFormState } from '@/hook/useFormState';
 
-const InputModal: React.FC = () => {
-  const defaultProps: InputModalProps = { ...propObj.default };
-  return <InputModalPresenter {...defaultProps} />;
+const InputModal: React.FC<InputModalContainerProps> = ({ clearModal, toDos, setToDos }) => {
+  // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
+  // PageMainでformStateの管理をすると、InputModalにバケツリレーするが、その際にInputModalPropsでhandleInput?:とオプショナルを指定すると、undefinedとなりInputModal.propsの中身と齟齬が生じる
+  // 結果としてInputModalで状態管理をすることとした。
+  const { formState, handleInput } = useFormState();
+  const onClearModal = (): void => clearModal();
+  const onCreateClick = (): void => {
+    const newToDos = [...toDos];
+    setToDos([...newToDos, { ...formState }]);
+    clearModal();
+  };
+  // 関数をpropsで親要素から子要素に受け継ぐ場合には子要素であらためて関数を定義する必要がある！
+  const logicProps: InputModalLogicProps = {
+    handleInput: handleInput,
+    clearModal: clearModal,
+    onClearModal: onClearModal,
+    onCreateClick: onCreateClick,
+    formState: formState,
+    toDos: toDos,
+    setToDos: setToDos,
+  };
+  const defaultProps: InputModalDataProps = { ...propObj.default };
+  return <InputModalPresenter {...defaultProps} {...logicProps} />;
 };
 
 export { InputModal };

--- a/src/component/common/template/InputModal/index.tsx
+++ b/src/component/common/template/InputModal/index.tsx
@@ -5,19 +5,22 @@ import {
   InputModalLogicProps,
   InputModalDataProps,
 } from './InputModal.type';
-import { useFormState } from '@/hook/useFormState';
 
-const InputModal: React.FC<InputModalContainerProps> = ({ type, clearModal, toDos, setToDos }) => {
+const InputModal: React.FC<InputModalContainerProps> = ({
+  type,
+  clearModal,
+  toDos,
+  setToDos,
+  formState,
+  onCreateClick,
+  handleInput,
+}) => {
   // PageMainでformStateの管理をすると、InputModalを消したあとに再び開くとformStateが維持されているがInputModalで管理するとModalを消すと消える。
   // PageMainでformStateの管理をすると、InputModalにバケツリレーするが、その際にInputModalPropsでhandleInput?:とオプショナルを指定すると、undefinedとなりInputModal.propsの中身と齟齬が生じる
   // 結果としてInputModalで状態管理をすることとした。
-  const { formState, handleInput } = useFormState();
+
   const onClearModal = (): void => clearModal();
-  const onCreateClick = (): void => {
-    const newToDos = [...toDos];
-    setToDos([...newToDos, { ...formState }]);
-    clearModal();
-  };
+
   // 関数をpropsで親要素から子要素に受け継ぐ場合には子要素であらためて関数を定義する必要がある！
   const logicProps: InputModalLogicProps = {
     type: type,

--- a/src/component/common/template/PageMain/PageMain.props.ts
+++ b/src/component/common/template/PageMain/PageMain.props.ts
@@ -1,9 +1,9 @@
 import { toDoProps, completedProps } from '../Card/Card.props';
 import { propObj as descriptionModalProps } from '../DescriptionModal/DescriptionModal.props';
-import { PageMainProps } from './PageMain';
+import { PageMainDataProps } from './PageMain.type';
 import { propObj as inputModalProps } from '@/component/common/template/InputModal/InputModal.props';
 
-const defaultProps: PageMainProps = {
+const defaultProps: PageMainDataProps = {
   toDoCard: toDoProps,
   completedCard: completedProps,
   descriptionModal: descriptionModalProps.default,
@@ -11,24 +11,6 @@ const defaultProps: PageMainProps = {
   updateModal: inputModalProps.update,
 };
 
-/**
- * const propObj への補足。
- * propObj の中身が3つ以上になる場合、以下のように書くと便利です。
- * 使わないときはこのコメントアウト部分は削除してください。
- */
-/*interface PropObj {
-  default: PageMainProps;
-  pattern1(適宜名称を変えてください): PageMainProps;
-  pattern2: PageMainProps;
-  ...
-}
-export const propObj: PropObj = {
-  default: defaultProps,
-    pattern1(適宜名称を変えてください): pattern1Props;
-  pattern2: pattern2Props;
-  ...
-}*/
-
-export const propObj: { [key: string]: PageMainProps } = {
+export const propObj: { [key: string]: PageMainDataProps } = {
   default: defaultProps,
 };

--- a/src/component/common/template/PageMain/PageMain.props.ts
+++ b/src/component/common/template/PageMain/PageMain.props.ts
@@ -4,8 +4,6 @@ import { PageMainDataProps } from './PageMain.type';
 import { propObj as inputModalProps } from '@/component/common/template/InputModal/InputModal.props';
 
 const defaultProps: PageMainDataProps = {
-  toDo: 'TO DO',
-  completed: 'COMPLETED',
   toDoCard: toDoProps,
   completedCard: completedProps,
   descriptionModal: descriptionModalProps.default,

--- a/src/component/common/template/PageMain/PageMain.props.ts
+++ b/src/component/common/template/PageMain/PageMain.props.ts
@@ -4,6 +4,8 @@ import { PageMainDataProps } from './PageMain.type';
 import { propObj as inputModalProps } from '@/component/common/template/InputModal/InputModal.props';
 
 const defaultProps: PageMainDataProps = {
+  toDo: 'TO DO',
+  completed: 'COMPLETED',
   toDoCard: toDoProps,
   completedCard: completedProps,
   descriptionModal: descriptionModalProps.default,

--- a/src/component/common/template/PageMain/PageMain.stories.tsx
+++ b/src/component/common/template/PageMain/PageMain.stories.tsx
@@ -1,14 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { PageMain } from './PageMain';
 import { propObj } from './PageMain.props';
-import { PageMainPresenterProps } from './PageMain.type';
+import { PageMainProps } from './PageMain.type';
+import { PageMain } from './index';
 
 export default {
   title: 'Common/template/PageMain',
   component: PageMain,
 } as ComponentMeta<typeof PageMain>;
 
-const Template: Story<PageMainPresenterProps> = (args) => <PageMain {...args} />;
+const Template: Story<PageMainProps> = (args) => <PageMain {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/PageMain/PageMain.stories.tsx
+++ b/src/component/common/template/PageMain/PageMain.stories.tsx
@@ -13,5 +13,5 @@ const Template: Story<PageMainPresenterProps> = (args) => <PageMain {...args} />
 export const Default = Template.bind({});
 Default.args = {
   ...propObj.default,
-  toDos: [{ isCompleted: false, title: 'name', description: 'description' }],
+  toDos: [{ isCompleted: false, title: 'name', description: 'description', id: -1 }],
 };

--- a/src/component/common/template/PageMain/PageMain.stories.tsx
+++ b/src/component/common/template/PageMain/PageMain.stories.tsx
@@ -1,13 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
-import { PageMain, PageMainProps } from './PageMain';
+import { PageMain } from './PageMain';
 import { propObj } from './PageMain.props';
+import { PageMainPresenterProps } from './PageMain.type';
 
 export default {
   title: 'Common/template/PageMain',
   component: PageMain,
 } as ComponentMeta<typeof PageMain>;
 
-const Template: Story<PageMainProps> = (args) => <PageMain {...args} />;
+const Template: Story<PageMainPresenterProps> = (args) => <PageMain {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/PageMain/PageMain.stories.tsx
+++ b/src/component/common/template/PageMain/PageMain.stories.tsx
@@ -1,14 +1,17 @@
 import type { ComponentMeta, Story } from '@storybook/react';
 import { PageMain } from './PageMain';
 import { propObj } from './PageMain.props';
-import { PageMainContainerProps } from './PageMain.type';
+import { PageMainPresenterProps } from './PageMain.type';
 
 export default {
   title: 'Common/template/PageMain',
   component: PageMain,
 } as ComponentMeta<typeof PageMain>;
 
-const Template: Story<PageMainContainerProps> = (args) => <PageMain {...args} />;
+const Template: Story<PageMainPresenterProps> = (args) => <PageMain {...args} />;
 
 export const Default = Template.bind({});
-Default.args = propObj.default;
+Default.args = {
+  ...propObj.default,
+  toDos: [{ isCompleted: false, title: 'name', description: 'description' }],
+};

--- a/src/component/common/template/PageMain/PageMain.stories.tsx
+++ b/src/component/common/template/PageMain/PageMain.stories.tsx
@@ -1,14 +1,14 @@
 import type { ComponentMeta, Story } from '@storybook/react';
+import { PageMain } from './PageMain';
 import { propObj } from './PageMain.props';
-import { PageMainProps } from './PageMain.type';
-import { PageMain } from './index';
+import { PageMainContainerProps } from './PageMain.type';
 
 export default {
   title: 'Common/template/PageMain',
   component: PageMain,
 } as ComponentMeta<typeof PageMain>;
 
-const Template: Story<PageMainProps> = (args) => <PageMain {...args} />;
+const Template: Story<PageMainContainerProps> = (args) => <PageMain {...args} />;
 
 export const Default = Template.bind({});
 Default.args = propObj.default;

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -83,6 +83,8 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         setToDos={setToDos}
       />
     )}
-    {modal === 'delete' && <DeleteModal clearModal={clearModal} />}
+    {modal === 'delete' && (
+      <DeleteModal clearModal={clearModal} descriptionClick={descriptionClick} />
+    )}
   </div>
 );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -1,38 +1,16 @@
-import { Dispatch, SetStateAction } from 'react';
-import { Card, CardProps } from '../Card/Card';
-import { DescriptionModal, DescriptionModalProps } from '../DescriptionModal/DescriptionModal';
+import { Card } from '../Card/Card';
+import { DescriptionModal } from '../DescriptionModal/DescriptionModal';
 import { InputModal } from '../InputModal';
-import { InputModalDataProps, InputModalLogic2Props } from '../InputModal/InputModal.type';
-import { ToDoProps } from '@/hook/useTodos';
-
-export interface PageMainProps {
-  toDoCard: CardProps;
-  completedCard: CardProps;
-  descriptionModal: DescriptionModalProps;
-  createModal: InputModalDataProps;
-  updateModal: InputModalDataProps;
-  logicProps: InputModalLogic2Props;
-}
-
-export interface PageMainFcProps extends PageMainProps {
-  toDos: ToDoProps[];
-  createClick: () => void;
-  descriptionClick: () => void;
-  updateClick: () => void;
-  clearModal: () => void;
-  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-  modal: string;
-}
+import { PageMainPresenterProps } from './PageMain.type';
 
 export const baseId = 'common-template-page-main';
 
-export const PageMain: React.FC<PageMainFcProps> = ({
+export const PageMain: React.FC<PageMainPresenterProps> = ({
   toDoCard,
   completedCard,
   descriptionModal,
   createModal,
   updateModal,
-  logicProps,
   toDos,
   createClick,
   descriptionClick,
@@ -56,22 +34,10 @@ export const PageMain: React.FC<PageMainFcProps> = ({
     </button>
     {modal === 'description' && <DescriptionModal {...descriptionModal} clearModal={clearModal} />}
     {modal === 'create' && (
-      <InputModal
-        {...createModal}
-        {...logicProps}
-        clearModal={clearModal}
-        toDos={toDos}
-        setToDos={setToDos}
-      />
+      <InputModal {...createModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
     )}
     {modal === 'update' && (
-      <InputModal
-        {...updateModal}
-        {...logicProps}
-        clearModal={clearModal}
-        toDos={toDos}
-        setToDos={setToDos}
-      />
+      <InputModal {...updateModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
     )}
   </div>
 );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -83,6 +83,6 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         setToDos={setToDos}
       />
     )}
-    {modal === 'delete' && <DeleteModal />}
+    {modal === 'delete' && <DeleteModal clearModal={clearModal} />}
   </div>
 );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -90,6 +90,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         toDos={toDos}
         setToDos={setToDos}
         selectToDo={selectToDo}
+        toDo={toDos[Number(selectToDo)]}
       />
     )}
   </div>

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -20,6 +20,9 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
   modal,
   selectToDo,
   setSelectToDo,
+  onCreateClick,
+  formState,
+  handleInput,
 }) => (
   <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
     <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
@@ -60,6 +63,9 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
     )}
     {modal === 'create' && (
       <InputModal
+        formState={formState}
+        handleInput={handleInput}
+        onCreateClick={onCreateClick}
         type='create'
         {...createModal}
         clearModal={clearModal}
@@ -69,6 +75,9 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
     )}
     {modal === 'update' && (
       <InputModal
+        formState={formState}
+        handleInput={handleInput}
+        onCreateClick={onCreateClick}
         type='update'
         {...updateModal}
         clearModal={clearModal}

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -6,8 +6,6 @@ import { PageMainPresenterProps } from './PageMain.type';
 export const baseId = 'common-template-page-main';
 
 export const PageMain: React.FC<PageMainPresenterProps> = ({
-  toDo,
-  completed,
   toDoCard,
   completedCard,
   descriptionModal,
@@ -26,7 +24,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
   <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
     <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
     <Card
-      type={toDo}
+      type='TO DO'
       {...toDoCard}
       toDos={toDos}
       handleClick={createClick}
@@ -35,7 +33,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
       selectToDo={selectToDo}
     />
     <Card
-      type={completed}
+      type='COMPLETED'
       {...completedCard}
       toDos={toDos}
       handleClick={createClick}

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -84,7 +84,13 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
       />
     )}
     {modal === 'delete' && (
-      <DeleteModal clearModal={clearModal} descriptionClick={descriptionClick} />
+      <DeleteModal
+        clearModal={clearModal}
+        descriptionClick={descriptionClick}
+        toDos={toDos}
+        setToDos={setToDos}
+        selectToDo={selectToDo}
+      />
     )}
   </div>
 );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -22,7 +22,7 @@ export const PageMain: React.FC<PageMainProps> = ({
   updateModal,
 }) => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
-  const { toDos, handleClick } = useTodos();
+  const { toDos, setToDos } = useTodos();
   return (
     <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
       <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
@@ -41,10 +41,10 @@ export const PageMain: React.FC<PageMainProps> = ({
         <DescriptionModal {...descriptionModal} clearModal={clearModal} />
       )}
       {modal === 'create' && (
-        <InputModal {...createModal} clearModal={clearModal} handleClick={handleClick} />
+        <InputModal {...createModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
       )}
       {modal === 'update' && (
-        <InputModal {...updateModal} clearModal={clearModal} handleClick={handleClick} />
+        <InputModal {...updateModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
       )}
     </div>
   );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -1,11 +1,12 @@
-import { Card, CardProps } from '../Card/Card';
+import { Card, CardFcProps } from '../Card/Card';
 import { DescriptionModal, DescriptionModalProps } from '../DescriptionModal/DescriptionModal';
 import { InputModal, InputModalProps } from '../InputModal/InputModal';
 import { useModal } from '@/hook/useModal';
+import { useTodos } from '@/hook/useTodos';
 
 export interface PageMainProps {
-  toDoCard: CardProps;
-  completedCard: CardProps;
+  toDoCard: CardFcProps;
+  completedCard: CardFcProps;
   descriptionModal: DescriptionModalProps;
   createModal: InputModalProps;
   updateModal: InputModalProps;
@@ -21,11 +22,12 @@ export const PageMain: React.FC<PageMainProps> = ({
   updateModal,
 }) => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
+  const { toDos, handleClick } = useTodos();
   return (
     <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
       <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
-      <Card {...toDoCard} />
-      <Card {...completedCard} />
+      <Card {...toDoCard} toDos={toDos} handleClick={createClick} />
+      <Card {...completedCard} toDos={toDos} handleClick={createClick} />
       <button className='btn green-gradient' onClick={descriptionClick}>
         description
       </button>
@@ -38,8 +40,12 @@ export const PageMain: React.FC<PageMainProps> = ({
       {modal === 'description' && (
         <DescriptionModal {...descriptionModal} clearModal={clearModal} />
       )}
-      {modal === 'create' && <InputModal {...createModal} clearModal={clearModal} />}
-      {modal === 'update' && <InputModal {...updateModal} clearModal={clearModal} />}
+      {modal === 'create' && (
+        <InputModal {...createModal} clearModal={clearModal} handleClick={handleClick} />
+      )}
+      {modal === 'update' && (
+        <InputModal {...updateModal} clearModal={clearModal} handleClick={handleClick} />
+      )}
     </div>
   );
 };

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -1,4 +1,4 @@
-import { Card } from '../Card/Card';
+import { Card } from '../Card/index';
 import { DescriptionModal } from '../DescriptionModal/DescriptionModal';
 import { InputModal } from '../InputModal';
 import { PageMainPresenterProps } from './PageMain.type';
@@ -6,6 +6,8 @@ import { PageMainPresenterProps } from './PageMain.type';
 export const baseId = 'common-template-page-main';
 
 export const PageMain: React.FC<PageMainPresenterProps> = ({
+  toDo,
+  completed,
   toDoCard,
   completedCard,
   descriptionModal,
@@ -18,20 +20,28 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
   clearModal,
   setToDos,
   modal,
+  selectToDo,
+  setSelectToDo,
 }) => (
   <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
     <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
     <Card
+      type={toDo}
       {...toDoCard}
       toDos={toDos}
       handleClick={createClick}
       descriptionClick={descriptionClick}
+      setSelectToDo={setSelectToDo}
+      selectToDo={selectToDo}
     />
     <Card
+      type={completed}
       {...completedCard}
       toDos={toDos}
       handleClick={createClick}
       descriptionClick={descriptionClick}
+      setSelectToDo={setSelectToDo}
+      selectToDo={selectToDo}
     />
     <button className='btn green-gradient' onClick={descriptionClick}>
       description
@@ -42,7 +52,13 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
     <button className='btn green-gradient' onClick={updateClick}>
       update
     </button>
-    {modal === 'description' && <DescriptionModal {...descriptionModal} clearModal={clearModal} />}
+    {modal === 'description' && (
+      <DescriptionModal
+        {...descriptionModal}
+        clearModal={clearModal}
+        toDo={toDos[Number(selectToDo)]}
+      />
+    )}
     {modal === 'create' && (
       <InputModal {...createModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
     )}

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -1,51 +1,77 @@
-import { Card, CardFcProps } from '../Card/Card';
+import { Dispatch, SetStateAction } from 'react';
+import { Card, CardProps } from '../Card/Card';
 import { DescriptionModal, DescriptionModalProps } from '../DescriptionModal/DescriptionModal';
-import { InputModal, InputModalProps } from '../InputModal/InputModal';
-import { useModal } from '@/hook/useModal';
-import { useTodos } from '@/hook/useTodos';
+import { InputModal } from '../InputModal';
+import { InputModalDataProps, InputModalLogic2Props } from '../InputModal/InputModal.type';
+import { ToDoProps } from '@/hook/useTodos';
 
 export interface PageMainProps {
-  toDoCard: CardFcProps;
-  completedCard: CardFcProps;
+  toDoCard: CardProps;
+  completedCard: CardProps;
   descriptionModal: DescriptionModalProps;
-  createModal: InputModalProps;
-  updateModal: InputModalProps;
+  createModal: InputModalDataProps;
+  updateModal: InputModalDataProps;
+  logicProps: InputModalLogic2Props;
+}
+
+export interface PageMainFcProps extends PageMainProps {
+  toDos: ToDoProps[];
+  createClick: () => void;
+  descriptionClick: () => void;
+  updateClick: () => void;
+  clearModal: () => void;
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  modal: string;
 }
 
 export const baseId = 'common-template-page-main';
 
-export const PageMain: React.FC<PageMainProps> = ({
+export const PageMain: React.FC<PageMainFcProps> = ({
   toDoCard,
   completedCard,
   descriptionModal,
   createModal,
   updateModal,
-}) => {
-  const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
-  const { toDos, setToDos } = useTodos();
-  return (
-    <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
-      <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
-      <Card {...toDoCard} toDos={toDos} handleClick={createClick} />
-      <Card {...completedCard} toDos={toDos} handleClick={createClick} />
-      <button className='btn green-gradient' onClick={descriptionClick}>
-        description
-      </button>
-      <button className='btn green-gradient' onClick={createClick}>
-        create
-      </button>
-      <button className='btn green-gradient' onClick={updateClick}>
-        update
-      </button>
-      {modal === 'description' && (
-        <DescriptionModal {...descriptionModal} clearModal={clearModal} />
-      )}
-      {modal === 'create' && (
-        <InputModal {...createModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
-      )}
-      {modal === 'update' && (
-        <InputModal {...updateModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
-      )}
-    </div>
-  );
-};
+  logicProps,
+  toDos,
+  createClick,
+  descriptionClick,
+  updateClick,
+  clearModal,
+  setToDos,
+  modal,
+}) => (
+  <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
+    <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
+    <Card {...toDoCard} toDos={toDos} handleClick={createClick} />
+    <Card {...completedCard} toDos={toDos} handleClick={createClick} />
+    <button className='btn green-gradient' onClick={descriptionClick}>
+      description
+    </button>
+    <button className='btn green-gradient' onClick={createClick}>
+      create
+    </button>
+    <button className='btn green-gradient' onClick={updateClick}>
+      update
+    </button>
+    {modal === 'description' && <DescriptionModal {...descriptionModal} clearModal={clearModal} />}
+    {modal === 'create' && (
+      <InputModal
+        {...createModal}
+        {...logicProps}
+        clearModal={clearModal}
+        toDos={toDos}
+        setToDos={setToDos}
+      />
+    )}
+    {modal === 'update' && (
+      <InputModal
+        {...updateModal}
+        {...logicProps}
+        clearModal={clearModal}
+        toDos={toDos}
+        setToDos={setToDos}
+      />
+    )}
+  </div>
+);

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -37,6 +37,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
       descriptionClick={descriptionClick}
       setSelectToDo={setSelectToDo}
       selectToDo={selectToDo}
+      setToDos={setToDos}
     />
     <Card
       type='COMPLETED'
@@ -46,6 +47,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
       descriptionClick={descriptionClick}
       setSelectToDo={setSelectToDo}
       selectToDo={selectToDo}
+      setToDos={setToDos}
     />
 
     {modal === 'description' && (

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -21,8 +21,18 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
 }) => (
   <div className='relative flex w-[420px] flex-col gap-y-5 bg-primary-50 p-8'>
     <span className='text-lg font-bold text-primary-700'>For what you wanna do!!</span>
-    <Card {...toDoCard} toDos={toDos} handleClick={createClick} />
-    <Card {...completedCard} toDos={toDos} handleClick={createClick} />
+    <Card
+      {...toDoCard}
+      toDos={toDos}
+      handleClick={createClick}
+      descriptionClick={descriptionClick}
+    />
+    <Card
+      {...completedCard}
+      toDos={toDos}
+      handleClick={createClick}
+      descriptionClick={descriptionClick}
+    />
     <button className='btn green-gradient' onClick={descriptionClick}>
       description
     </button>

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -14,7 +14,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
   toDos,
   createClick,
   descriptionClick,
-  updateClick,
+  updateSetClick,
   clearModal,
   setToDos,
   modal,
@@ -44,19 +44,11 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
       setSelectToDo={setSelectToDo}
       selectToDo={selectToDo}
     />
-    <button className='btn green-gradient' onClick={descriptionClick}>
-      description
-    </button>
-    <button className='btn green-gradient' onClick={createClick}>
-      create
-    </button>
-    <button className='btn green-gradient' onClick={updateClick}>
-      update
-    </button>
+
     {modal === 'description' && (
       <DescriptionModal
         {...descriptionModal}
-        updateClick={updateClick}
+        updateSetClick={updateSetClick}
         clearModal={clearModal}
         toDo={toDos[Number(selectToDo)]}
       />

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -1,5 +1,6 @@
 import { Card } from '../Card/index';
-import { DescriptionModal } from '../DescriptionModal/DescriptionModal';
+import { DeleteModal } from '../DeleteModal';
+import { DescriptionModal } from '../DescriptionModal/';
 import { InputModal } from '../InputModal';
 import { PageMainPresenterProps } from './PageMain.type';
 
@@ -15,6 +16,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
   createClick,
   descriptionClick,
   updateSetClick,
+  deleteSetClick,
   clearModal,
   setToDos,
   modal,
@@ -50,6 +52,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
       <DescriptionModal
         {...descriptionModal}
         updateSetClick={updateSetClick}
+        deleteSetClick={deleteSetClick}
         clearModal={clearModal}
         toDo={toDos[Number(selectToDo)]}
       />
@@ -80,5 +83,6 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         setToDos={setToDos}
       />
     )}
+    {modal === 'delete' && <DeleteModal />}
   </div>
 );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -53,15 +53,28 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
     {modal === 'description' && (
       <DescriptionModal
         {...descriptionModal}
+        updateClick={updateClick}
         clearModal={clearModal}
         toDo={toDos[Number(selectToDo)]}
       />
     )}
     {modal === 'create' && (
-      <InputModal {...createModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
+      <InputModal
+        type='create'
+        {...createModal}
+        clearModal={clearModal}
+        toDos={toDos}
+        setToDos={setToDos}
+      />
     )}
     {modal === 'update' && (
-      <InputModal {...updateModal} clearModal={clearModal} toDos={toDos} setToDos={setToDos} />
+      <InputModal
+        type='update'
+        {...updateModal}
+        clearModal={clearModal}
+        toDos={toDos}
+        setToDos={setToDos}
+      />
     )}
   </div>
 );

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -21,6 +21,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
   selectToDo,
   setSelectToDo,
   onCreateClick,
+  onUpdateClick,
   formState,
   handleInput,
 }) => (
@@ -58,6 +59,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         formState={formState}
         handleInput={handleInput}
         onCreateClick={onCreateClick}
+        onUpdateClick={onUpdateClick}
         type='create'
         {...createModal}
         clearModal={clearModal}
@@ -70,6 +72,7 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         formState={formState}
         handleInput={handleInput}
         onCreateClick={onCreateClick}
+        onUpdateClick={onUpdateClick}
         type='update'
         {...updateModal}
         clearModal={clearModal}

--- a/src/component/common/template/PageMain/PageMain.tsx
+++ b/src/component/common/template/PageMain/PageMain.tsx
@@ -90,7 +90,6 @@ export const PageMain: React.FC<PageMainPresenterProps> = ({
         toDos={toDos}
         setToDos={setToDos}
         selectToDo={selectToDo}
-        toDo={toDos[Number(selectToDo)]}
       />
     )}
   </div>

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -22,8 +22,13 @@ export interface PageMainPresenterProps extends PageMainDataProps {
   modal: string;
 }
 
-// PageMainのPresenterに含まれない親コンポーネントから受け継ぐ要素は今のところないので不要
-// export interface PageMainContainerProps extends PageMainPresenterProps {
+// 親コンポーネントから受け継ぐ要素は今のところないので不要
+// export interface PageMainContainerProps  {
+
+// }
+
+// Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるので不要
+// export interface PageMainProps extends PageMainPresenterProps {
 
 // }
 

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -5,8 +5,6 @@ import { InputModalDataProps } from '../InputModal/InputModal.type';
 import { ToDoProps } from '@/hook/useTodos';
 
 export interface PageMainDataProps {
-  toDo: 'TO DO' | 'COMPLETED';
-  completed: 'TO DO' | 'COMPLETED';
   toDoCard: CardDataProps;
   completedCard: CardDataProps;
   descriptionModal: DescriptionModalDataProps;

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -19,7 +19,7 @@ export interface PageMainPresenterProps extends PageMainDataProps {
   toDos: ToDoProps[];
   createClick: () => void;
   descriptionClick: () => void;
-  updateClick: () => void;
+  updateSetClick: () => void;
   clearModal: () => void;
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
   modal: string;
@@ -56,7 +56,7 @@ export interface PageMainLogicProps {
   clearModal: () => void;
   descriptionClick: () => void;
   createClick: () => void;
-  updateClick: () => void;
+  updateSetClick: () => void;
   selectToDo: string;
   setSelectToDo: Dispatch<SetStateAction<string>>;
 }

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -21,6 +21,7 @@ export interface PageMainPresenterProps extends PageMainDataProps {
   createClick: () => void;
   descriptionClick: () => void;
   updateSetClick: () => void;
+  deleteSetClick: () => void;
   clearModal: () => void;
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
   modal: string;
@@ -59,6 +60,7 @@ export interface PageMainLogicProps {
   descriptionClick: () => void;
   createClick: () => void;
   updateSetClick: () => void;
+  deleteSetClick: () => void;
   selectToDo: string;
   setSelectToDo: Dispatch<SetStateAction<string>>;
 }

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -26,15 +26,11 @@ export interface PageMainPresenterProps extends PageMainDataProps {
   setSelectToDo: Dispatch<SetStateAction<string>>;
 }
 
-// 親コンポーネントから受け継ぐ要素は今のところないので不要
-// export interface PageMainContainerProps  {
+// 親コンポーネントから受け継ぐ要素は今のところないが必要そう
+export type PageMainContainerProps = PageMainPresenterProps;
 
-// }
-
-// Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるので不要
-// export interface PageMainProps extends PageMainPresenterProps {
-
-// }
+// Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるが必要そう
+export type PageMainProps = PageMainPresenterProps;
 
 //Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -25,10 +25,30 @@ export interface PageMainPresenterProps extends PageMainDataProps {
 }
 
 // 親コンポーネントから受け継ぐ要素は今のところないが必要そう
-export type PageMainContainerProps = PageMainPresenterProps;
+export interface PageMainContainerProps extends PageMainDataProps {
+  toDos: ToDoProps[];
+  createClick: () => void;
+  descriptionClick: () => void;
+  updateClick: () => void;
+  clearModal: () => void;
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  modal: string;
+  selectToDo: string;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
+}
 
 // Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるが必要そう
-export type PageMainProps = PageMainPresenterProps;
+export interface PageMainProps extends PageMainDataProps {
+  toDos: ToDoProps[];
+  createClick: () => void;
+  descriptionClick: () => void;
+  updateClick: () => void;
+  clearModal: () => void;
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  modal: string;
+  selectToDo: string;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
+}
 
 //Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -1,12 +1,12 @@
 import { Dispatch, SetStateAction } from 'react';
-import { CardProps } from '../Card/Card';
+import { CardDataProps } from '../Card/Card.type';
 import { DescriptionModalProps } from '../DescriptionModal/DescriptionModal';
 import { InputModalDataProps } from '../InputModal/InputModal.type';
 import { ToDoProps } from '@/hook/useTodos';
 
 export interface PageMainDataProps {
-  toDoCard: CardProps;
-  completedCard: CardProps;
+  toDoCard: CardDataProps;
+  completedCard: CardDataProps;
   descriptionModal: DescriptionModalProps;
   createModal: InputModalDataProps;
   updateModal: InputModalDataProps;

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -1,0 +1,38 @@
+import { Dispatch, SetStateAction } from 'react';
+import { CardProps } from '../Card/Card';
+import { DescriptionModalProps } from '../DescriptionModal/DescriptionModal';
+import { InputModalDataProps } from '../InputModal/InputModal.type';
+import { ToDoProps } from '@/hook/useTodos';
+
+export interface PageMainDataProps {
+  toDoCard: CardProps;
+  completedCard: CardProps;
+  descriptionModal: DescriptionModalProps;
+  createModal: InputModalDataProps;
+  updateModal: InputModalDataProps;
+}
+
+export interface PageMainPresenterProps extends PageMainDataProps {
+  toDos: ToDoProps[];
+  createClick: () => void;
+  descriptionClick: () => void;
+  updateClick: () => void;
+  clearModal: () => void;
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  modal: string;
+}
+
+// PageMainのPresenterに含まれない親コンポーネントから受け継ぐ要素は今のところないので不要
+// export interface PageMainContainerProps extends PageMainPresenterProps {
+
+// }
+
+export interface PageMainLogicProps {
+  modal: string;
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  clearModal: () => void;
+  descriptionClick: () => void;
+  createClick: () => void;
+  updateClick: () => void;
+}

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -32,6 +32,7 @@ export interface PageMainPresenterProps extends PageMainDataProps {
 
 // }
 
+//Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {
   modal: string;
   toDos: ToDoProps[];

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -37,18 +37,7 @@ export interface PageMainContainerProps extends PageMainDataProps {
   setSelectToDo: Dispatch<SetStateAction<string>>;
 }
 
-// Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるが必要そう
-export interface PageMainProps extends PageMainDataProps {
-  toDos: ToDoProps[];
-  createClick: () => void;
-  descriptionClick: () => void;
-  updateClick: () => void;
-  clearModal: () => void;
-  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-  modal: string;
-  selectToDo: string;
-  setSelectToDo: Dispatch<SetStateAction<string>>;
-}
+// Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるが必要そう→不要
 
 //Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -14,6 +14,7 @@ export interface PageMainDataProps {
 
 export interface PageMainPresenterProps extends PageMainDataProps {
   onCreateClick: () => void;
+  onUpdateClick: () => void;
   formState: ToDoProps;
   handleInput: (key: string, value: string) => void;
   toDos: ToDoProps[];
@@ -48,6 +49,7 @@ export interface PageMainPresenterProps extends PageMainDataProps {
 //Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {
   onCreateClick: () => void;
+  onUpdateClick: () => void;
   formState: ToDoProps;
   handleInput: (key: string, value: string) => void;
   modal: string;

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -49,6 +49,7 @@ export interface PageMainPresenterProps extends PageMainDataProps {
 
 //Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {
+  countId: () => void;
   onCreateClick: () => void;
   onUpdateClick: () => void;
   formState: ToDoProps;

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -1,13 +1,15 @@
 import { Dispatch, SetStateAction } from 'react';
 import { CardDataProps } from '../Card/Card.type';
-import { DescriptionModalProps } from '../DescriptionModal/DescriptionModal';
+import { DescriptionModalDataProps } from '../DescriptionModal/DescriptionModal.type';
 import { InputModalDataProps } from '../InputModal/InputModal.type';
 import { ToDoProps } from '@/hook/useTodos';
 
 export interface PageMainDataProps {
+  toDo: 'TO DO' | 'COMPLETED';
+  completed: 'TO DO' | 'COMPLETED';
   toDoCard: CardDataProps;
   completedCard: CardDataProps;
-  descriptionModal: DescriptionModalProps;
+  descriptionModal: DescriptionModalDataProps;
   createModal: InputModalDataProps;
   updateModal: InputModalDataProps;
 }
@@ -20,6 +22,8 @@ export interface PageMainPresenterProps extends PageMainDataProps {
   clearModal: () => void;
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
   modal: string;
+  selectToDo: string;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
 }
 
 // 親コンポーネントから受け継ぐ要素は今のところないので不要
@@ -41,4 +45,6 @@ export interface PageMainLogicProps {
   descriptionClick: () => void;
   createClick: () => void;
   updateClick: () => void;
+  selectToDo: string;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
 }

--- a/src/component/common/template/PageMain/PageMain.type.ts
+++ b/src/component/common/template/PageMain/PageMain.type.ts
@@ -13,6 +13,9 @@ export interface PageMainDataProps {
 }
 
 export interface PageMainPresenterProps extends PageMainDataProps {
+  onCreateClick: () => void;
+  formState: ToDoProps;
+  handleInput: (key: string, value: string) => void;
   toDos: ToDoProps[];
   createClick: () => void;
   descriptionClick: () => void;
@@ -25,22 +28,28 @@ export interface PageMainPresenterProps extends PageMainDataProps {
 }
 
 // 親コンポーネントから受け継ぐ要素は今のところないが必要そう
-export interface PageMainContainerProps extends PageMainDataProps {
-  toDos: ToDoProps[];
-  createClick: () => void;
-  descriptionClick: () => void;
-  updateClick: () => void;
-  clearModal: () => void;
-  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-  modal: string;
-  selectToDo: string;
-  setSelectToDo: Dispatch<SetStateAction<string>>;
-}
+// export interface PageMainContainerProps extends PageMainDataProps {
+//   onCreateClick: () => void;
+//   formState: ToDoProps;
+//   handleInput: (key: string, value: string) => void;
+//   toDos: ToDoProps[];
+//   createClick: () => void;
+//   descriptionClick: () => void;
+//   updateClick: () => void;
+//   clearModal: () => void;
+//   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+//   modal: string;
+//   selectToDo: string;
+//   setSelectToDo: Dispatch<SetStateAction<string>>;
+// }
 
 // Storybook用のすべてを含んだ型はPageMainPresenterPropsに含まれるが必要そう→不要
 
 //Container内部で新たに生じたLogicの型定義
 export interface PageMainLogicProps {
+  onCreateClick: () => void;
+  formState: ToDoProps;
+  handleInput: (key: string, value: string) => void;
   modal: string;
   toDos: ToDoProps[];
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, SetStateAction } from 'react';
-import { PageMain as PageMainPresenter, PageMainProps } from './PageMain';
+import { PageMain as PageMainPresenter } from './PageMain';
 import { propObj } from './PageMain.props';
+import { PageMainDataProps, PageMainLogicProps } from './PageMain.type';
 import { useModal } from '@/hook/useModal';
-import { ToDoProps, useTodos } from '@/hook/useTodos';
+import { useTodos } from '@/hook/useTodos';
 /**
  * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
  * 存在する場合はコメントアウト部分を全て削除して使ってください。
@@ -12,20 +12,10 @@ export type { PageMainProps };
 export { PageMainPresenter};
 */
 
-type PageMainContainerProps = {
-  modal: string;
-  toDos: ToDoProps[];
-  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
-  clearModal: () => void;
-  descriptionClick: () => void;
-  createClick: () => void;
-  updateClick: () => void;
-};
-
 const PageMain: React.FC = () => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
   const { toDos, setToDos } = useTodos();
-  const logicProps: PageMainContainerProps = {
+  const logicProps: PageMainLogicProps = {
     modal: modal,
     toDos: toDos,
     descriptionClick: descriptionClick,
@@ -35,7 +25,7 @@ const PageMain: React.FC = () => {
     setToDos: setToDos,
   };
 
-  const defaultProps: PageMainProps = { ...propObj.default };
+  const defaultProps: PageMainDataProps = { ...propObj.default };
   return <PageMainPresenter {...defaultProps} {...logicProps} />;
 };
 

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -1,19 +1,11 @@
 import { PageMain as PageMainPresenter } from './PageMain';
 import { propObj } from './PageMain.props';
-import { PageMainDataProps, PageMainLogicProps } from './PageMain.type';
+import { PageMainDataProps, PageMainLogicProps, PageMainContainerProps } from './PageMain.type';
 import { useModal } from '@/hook/useModal';
 import { useSelectToDo } from '@/hook/useSelectToDo';
 import { useTodos } from '@/hook/useTodos';
-/**
- * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
- * 存在する場合はコメントアウト部分を全て削除して使ってください。
- */
-/* 
-export type { PageMainProps };
-export { PageMainPresenter};
-*/
 
-const PageMain: React.FC = () => {
+const PageMain: React.FC<PageMainContainerProps> = () => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
   const { toDos, setToDos } = useTodos();
   const { selectToDo, setSelectToDo } = useSelectToDo();

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -17,12 +17,21 @@ const PageMain: React.FC = () => {
     setFormState(initialForm);
     clearModal();
   };
+  const onUpdateClick = (): void => {
+    const newToDos = [...toDos];
+    newToDos[Number(selectToDo)] = { ...formState };
+    setToDos([...newToDos]);
+    setFormState(initialForm);
+    clearModal();
+  };
+  // update時にselectToDoの初期化はしていない
   const updateSetClick = (): void => {
     setFormState(toDos[Number(selectToDo)]);
     updateClick();
   };
   const logicProps: PageMainLogicProps = {
     onCreateClick: onCreateClick,
+    onUpdateClick: onUpdateClick,
     formState: formState,
     handleInput: handleInput,
     modal: modal,

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -1,6 +1,8 @@
+import { Dispatch, SetStateAction } from 'react';
 import { PageMain as PageMainPresenter, PageMainProps } from './PageMain';
 import { propObj } from './PageMain.props';
-
+import { useModal } from '@/hook/useModal';
+import { ToDoProps, useTodos } from '@/hook/useTodos';
 /**
  * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
  * 存在する場合はコメントアウト部分を全て削除して使ってください。
@@ -10,9 +12,31 @@ export type { PageMainProps };
 export { PageMainPresenter};
 */
 
+type PageMainContainerProps = {
+  modal: string;
+  toDos: ToDoProps[];
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
+  clearModal: () => void;
+  descriptionClick: () => void;
+  createClick: () => void;
+  updateClick: () => void;
+};
+
 const PageMain: React.FC = () => {
+  const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
+  const { toDos, setToDos } = useTodos();
+  const logicProps: PageMainContainerProps = {
+    modal: modal,
+    toDos: toDos,
+    descriptionClick: descriptionClick,
+    clearModal: clearModal,
+    createClick: createClick,
+    updateClick: updateClick,
+    setToDos: setToDos,
+  };
+
   const defaultProps: PageMainProps = { ...propObj.default };
-  return <PageMainPresenter {...defaultProps} />;
+  return <PageMainPresenter {...defaultProps} {...logicProps} />;
 };
 
 export { PageMain };

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -10,11 +10,16 @@ const PageMain: React.FC = () => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
   const { toDos, setToDos } = useTodos();
   const { selectToDo, setSelectToDo } = useSelectToDo();
-  const { formState, handleInput } = useFormState();
+  const { formState, setFormState, initialForm, handleInput } = useFormState();
   const onCreateClick = (): void => {
     const newToDos = [...toDos];
     setToDos([...newToDos, { ...formState }]);
+    setFormState(initialForm);
     clearModal();
+  };
+  const updateSetClick = (): void => {
+    setFormState(toDos[Number(selectToDo)]);
+    updateClick();
   };
   const logicProps: PageMainLogicProps = {
     onCreateClick: onCreateClick,
@@ -25,7 +30,7 @@ const PageMain: React.FC = () => {
     descriptionClick: descriptionClick,
     clearModal: clearModal,
     createClick: createClick,
-    updateClick: updateClick,
+    updateSetClick: updateSetClick,
     setToDos: setToDos,
     selectToDo: selectToDo,
     setSelectToDo: setSelectToDo,

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -7,7 +7,7 @@ import { useSelectToDo } from '@/hook/useSelectToDo';
 import { useTodos } from '@/hook/useTodos';
 
 const PageMain: React.FC = () => {
-  const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
+  const { modal, descriptionClick, clearModal, createClick, updateClick, deleteClick } = useModal();
   const { toDos, setToDos } = useTodos();
   const { selectToDo, setSelectToDo } = useSelectToDo();
   const { formState, setFormState, initialForm, handleInput } = useFormState();
@@ -29,6 +29,9 @@ const PageMain: React.FC = () => {
     setFormState(toDos[Number(selectToDo)]);
     updateClick();
   };
+  const deleteSetClick = (): void => {
+    deleteClick();
+  };
   const logicProps: PageMainLogicProps = {
     onCreateClick: onCreateClick,
     onUpdateClick: onUpdateClick,
@@ -40,6 +43,7 @@ const PageMain: React.FC = () => {
     clearModal: clearModal,
     createClick: createClick,
     updateSetClick: updateSetClick,
+    deleteSetClick: deleteSetClick,
     setToDos: setToDos,
     selectToDo: selectToDo,
     setSelectToDo: setSelectToDo,

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -2,6 +2,7 @@ import { PageMain as PageMainPresenter } from './PageMain';
 import { propObj } from './PageMain.props';
 import { PageMainDataProps, PageMainLogicProps } from './PageMain.type';
 import { useModal } from '@/hook/useModal';
+import { useSelectToDo } from '@/hook/useSelectToDo';
 import { useTodos } from '@/hook/useTodos';
 /**
  * ロジックが存在しない（= Container が要らない）場合は 以下と置き換えてください。
@@ -15,6 +16,7 @@ export { PageMainPresenter};
 const PageMain: React.FC = () => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
   const { toDos, setToDos } = useTodos();
+  const { selectToDo, setSelectToDo } = useSelectToDo();
   const logicProps: PageMainLogicProps = {
     modal: modal,
     toDos: toDos,
@@ -23,6 +25,8 @@ const PageMain: React.FC = () => {
     createClick: createClick,
     updateClick: updateClick,
     setToDos: setToDos,
+    selectToDo: selectToDo,
+    setSelectToDo: setSelectToDo,
   };
 
   const defaultProps: PageMainDataProps = { ...propObj.default };

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -2,20 +2,24 @@ import { PageMain as PageMainPresenter } from './PageMain';
 import { propObj } from './PageMain.props';
 import { PageMainDataProps, PageMainLogicProps } from './PageMain.type';
 import { useFormState } from '@/hook/useFormState';
+import { useId } from '@/hook/useId';
 import { useModal } from '@/hook/useModal';
 import { useSelectToDo } from '@/hook/useSelectToDo';
 import { useTodos } from '@/hook/useTodos';
 
 const PageMain: React.FC = () => {
+  const { id, countId } = useId();
   const { modal, descriptionClick, clearModal, createClick, updateClick, deleteClick } = useModal();
   const { toDos, setToDos } = useTodos();
   const { selectToDo, setSelectToDo } = useSelectToDo();
-  const { formState, setFormState, initialForm, handleInput } = useFormState();
+  const { formState, setFormState, initialForm, handleInput } = useFormState(id);
   const onCreateClick = (): void => {
     const newToDos = [...toDos];
     setToDos([...newToDos, { ...formState }]);
+    countId();
     setFormState(initialForm);
     clearModal();
+    console.log(newToDos, id);
   };
   const onUpdateClick = (): void => {
     const newToDos = [...toDos];
@@ -33,6 +37,7 @@ const PageMain: React.FC = () => {
     deleteClick();
   };
   const logicProps: PageMainLogicProps = {
+    countId: countId,
     onCreateClick: onCreateClick,
     onUpdateClick: onUpdateClick,
     formState: formState,

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -1,11 +1,11 @@
 import { PageMain as PageMainPresenter } from './PageMain';
 import { propObj } from './PageMain.props';
-import { PageMainDataProps, PageMainLogicProps, PageMainContainerProps } from './PageMain.type';
+import { PageMainDataProps, PageMainLogicProps } from './PageMain.type';
 import { useModal } from '@/hook/useModal';
 import { useSelectToDo } from '@/hook/useSelectToDo';
 import { useTodos } from '@/hook/useTodos';
 
-const PageMain: React.FC<PageMainContainerProps> = () => {
+const PageMain: React.FC = () => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
   const { toDos, setToDos } = useTodos();
   const { selectToDo, setSelectToDo } = useSelectToDo();

--- a/src/component/common/template/PageMain/index.tsx
+++ b/src/component/common/template/PageMain/index.tsx
@@ -1,6 +1,7 @@
 import { PageMain as PageMainPresenter } from './PageMain';
 import { propObj } from './PageMain.props';
 import { PageMainDataProps, PageMainLogicProps } from './PageMain.type';
+import { useFormState } from '@/hook/useFormState';
 import { useModal } from '@/hook/useModal';
 import { useSelectToDo } from '@/hook/useSelectToDo';
 import { useTodos } from '@/hook/useTodos';
@@ -9,7 +10,16 @@ const PageMain: React.FC = () => {
   const { modal, descriptionClick, clearModal, createClick, updateClick } = useModal();
   const { toDos, setToDos } = useTodos();
   const { selectToDo, setSelectToDo } = useSelectToDo();
+  const { formState, handleInput } = useFormState();
+  const onCreateClick = (): void => {
+    const newToDos = [...toDos];
+    setToDos([...newToDos, { ...formState }]);
+    clearModal();
+  };
   const logicProps: PageMainLogicProps = {
+    onCreateClick: onCreateClick,
+    formState: formState,
+    handleInput: handleInput,
     modal: modal,
     toDos: toDos,
     descriptionClick: descriptionClick,

--- a/src/hook/useFormState.ts
+++ b/src/hook/useFormState.ts
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
 import { ToDoProps } from '@/hook/useTodos';
 
 interface UseFormStateReturnType {
+  setFormState: Dispatch<SetStateAction<ToDoProps>>;
   formState: ToDoProps;
+  initialForm: ToDoProps;
   handleInput: (key: string, value: string) => void;
 }
 
@@ -14,5 +16,5 @@ export const useFormState = (): UseFormStateReturnType => {
     setFormState(newFormState);
     console.log(newFormState);
   };
-  return { formState, handleInput };
+  return { formState, setFormState, initialForm, handleInput };
 };

--- a/src/hook/useFormState.ts
+++ b/src/hook/useFormState.ts
@@ -8,8 +8,8 @@ interface UseFormStateReturnType {
   handleInput: (key: string, value: string) => void;
 }
 
-export const useFormState = (): UseFormStateReturnType => {
-  const initialForm: ToDoProps = { title: '', description: '', isCompleted: false };
+export const useFormState = (id: number): UseFormStateReturnType => {
+  const initialForm: ToDoProps = { title: '', description: '', isCompleted: false, id: id };
   const [formState, setFormState] = useState<ToDoProps>(initialForm);
   const handleInput = (key: string, value: string) => {
     const newFormState = { ...formState, [key]: value };

--- a/src/hook/useId.ts
+++ b/src/hook/useId.ts
@@ -1,0 +1,15 @@
+import { useState, Dispatch, SetStateAction } from 'react';
+
+export interface UseIdReturntype {
+  id: number;
+  setId: Dispatch<SetStateAction<number>>;
+  countId: () => void;
+}
+
+export const useId = (): UseIdReturntype => {
+  const [id, setId] = useState<number>(0);
+  const countId = (): void => {
+    setId((id) => (id += 1));
+  };
+  return { id, setId, countId };
+};

--- a/src/hook/useModal.ts
+++ b/src/hook/useModal.ts
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
 
-type ModalProps = 'description' | 'create' | 'update' | 'delete' | '';
+export type ModalProps = 'description' | 'create' | 'update' | 'delete' | '';
 
 interface UseModalReturnType {
+  setModal: Dispatch<SetStateAction<ModalProps>>;
   modal: ModalProps;
   descriptionClick: () => void;
   clearModal: () => void;
@@ -24,5 +25,5 @@ export const useModal = (): UseModalReturnType => {
   const updateClick = () => {
     setModal('update');
   };
-  return { modal, descriptionClick, clearModal, createClick, updateClick };
+  return { setModal, modal, descriptionClick, clearModal, createClick, updateClick };
 };

--- a/src/hook/useModal.ts
+++ b/src/hook/useModal.ts
@@ -9,6 +9,7 @@ interface UseModalReturnType {
   clearModal: () => void;
   createClick: () => void;
   updateClick: () => void;
+  deleteClick: () => void;
 }
 
 export const useModal = (): UseModalReturnType => {
@@ -25,5 +26,8 @@ export const useModal = (): UseModalReturnType => {
   const updateClick = () => {
     setModal('update');
   };
-  return { setModal, modal, descriptionClick, clearModal, createClick, updateClick };
+  const deleteClick = () => {
+    setModal('delete');
+  };
+  return { setModal, modal, descriptionClick, clearModal, createClick, updateClick, deleteClick };
 };

--- a/src/hook/useSelectToDo.ts
+++ b/src/hook/useSelectToDo.ts
@@ -1,0 +1,11 @@
+import { useState, Dispatch, SetStateAction } from 'react';
+
+export interface UseSelectToDoReturnType {
+  selectToDo: string;
+  setSelectToDo: Dispatch<SetStateAction<string>>;
+}
+
+export const useSelectToDo = (): UseSelectToDoReturnType => {
+  const [selectToDo, setSelectToDo] = useState<string>('');
+  return { selectToDo, setSelectToDo };
+};

--- a/src/hook/useTodos.ts
+++ b/src/hook/useTodos.ts
@@ -20,7 +20,8 @@ export const useTodos = (): UseTodosReturnType => {
   const initialToDos = [...toDoList];
   const [toDos, setToDos] = useState<ToDoProps[]>(initialToDos);
   const handleClick = () => {
-    setToDos([...toDos, { title: '新規', isCompleted: false, description: '新規' }]);
+    const newToDos = [...toDos];
+    setToDos([...newToDos, { title: '新規', isCompleted: false, description: '新規' }]);
   };
   return { toDos, handleClick };
 };

--- a/src/hook/useTodos.ts
+++ b/src/hook/useTodos.ts
@@ -4,6 +4,7 @@ export interface ToDoProps {
   title: string;
   isCompleted: boolean;
   description: string;
+  id: number;
 }
 
 interface UseTodosReturnType {
@@ -12,8 +13,8 @@ interface UseTodosReturnType {
 }
 
 const toDoList: ToDoProps[] = [
-  { title: 'テキスト1', isCompleted: false, description: 'テキスト1' },
-  { title: 'テキスト2', isCompleted: false, description: 'テキスト2' },
+  { title: 'テキスト1', isCompleted: false, description: 'テキスト1', id: -2 },
+  { title: 'テキスト2', isCompleted: false, description: 'テキスト2', id: -1 },
 ];
 
 export const useTodos = (): UseTodosReturnType => {

--- a/src/hook/useTodos.ts
+++ b/src/hook/useTodos.ts
@@ -12,14 +12,14 @@ interface UseTodosReturnType {
   setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
-const toDoList: ToDoProps[] = [
-  { title: 'テキスト1', isCompleted: false, description: 'テキスト1', id: -2 },
-  { title: 'テキスト2', isCompleted: false, description: 'テキスト2', id: -1 },
-];
+// const toDoList: ToDoProps[] = [
+//   { title: 'テキスト1', isCompleted: false, description: 'テキスト1', id: -2 },
+//   { title: 'テキスト2', isCompleted: false, description: 'テキスト2', id: -1 },
+// ];
 
 export const useTodos = (): UseTodosReturnType => {
-  const initialToDos = [...toDoList];
-  const [toDos, setToDos] = useState<ToDoProps[]>(initialToDos);
+  // const initialToDos = [...toDoList];
+  const [toDos, setToDos] = useState<ToDoProps[]>([]);
 
   return { toDos, setToDos };
 };

--- a/src/hook/useTodos.ts
+++ b/src/hook/useTodos.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
 
 export interface ToDoProps {
   title: string;
@@ -8,7 +8,7 @@ export interface ToDoProps {
 
 interface UseTodosReturnType {
   toDos: ToDoProps[];
-  handleClick: () => void;
+  setToDos: Dispatch<SetStateAction<ToDoProps[]>>;
 }
 
 const toDoList: ToDoProps[] = [
@@ -19,9 +19,6 @@ const toDoList: ToDoProps[] = [
 export const useTodos = (): UseTodosReturnType => {
   const initialToDos = [...toDoList];
   const [toDos, setToDos] = useState<ToDoProps[]>(initialToDos);
-  const handleClick = () => {
-    const newToDos = [...toDos];
-    setToDos([...newToDos, { title: '新規', isCompleted: false, description: '新規' }]);
-  };
-  return { toDos, handleClick };
+
+  return { toDos, setToDos };
 };

--- a/src/style/globals.css
+++ b/src/style/globals.css
@@ -20,3 +20,7 @@
 .form {
   @apply h-10 w-52 rounded-md border-2 border-primary-700 px-2 text-primary-800 focus:border-primary-200 focus:outline-none focus:ring-0;
 }
+
+.textarea {
+  @apply h-52 w-52 rounded-md border-2 border-primary-700 px-2 text-primary-800 focus:border-primary-200 focus:outline-none focus:ring-0;
+}


### PR DESCRIPTION
- [x] formStateの状態管理（InputModalで管理）
- [x] toDosの状態管理（Cardで管理）
- [x] modalの状態管理（PageMainで管理）
- [x] toDosの状態管理をPageMainに変更しmodal内部で利用できるようにする
- [x] toDos/setToDosをInputModalのpropsとして受け渡す
- [x] createの実装
- [x] selectToDoの状態管理（PageMainで管理）
- [x] readの実装
- [x] formStateの状態管理をPageMainに変更
- [x] updateの実装
- [x] DescriptionModalに削除ボタンを追加
- [x] deleteの実装
- [x] checkによる移動の実装
- [ ] countUp で toDo に ID を発行する（toDos.filter.map で isCompleted を分けて表示すると map の部分で selectToDo がおかしくなり、Completed から ToDo に戻せなくなった。map の中で 三項演算子をすると react.node/children のエラーでうまくいかない）

【状態管理の状況】
+ formState
- [x] InputModal（下記変更）
- [x] PageMain→InputModal
+ setFormState
- [x] InputModal（下記変更）
- [x] PageMain→InputModal
- [x] PageMain→DescriptionModal
+ toDos
- [x] PageMain→Card
- [x] PageMain→InputModal
- [x] **PageMain→DeleteModal**
+ toDos['selectToDo']
- [x] PageMain→DescriptionModal
+ setToDos
- [x] PageMain→InputModal
- [x] **PageMain→DeleteModal**
- [x] PageMain→Card
+ selectToDo
- [x] PageMain→Card
- [x] **PageMain→InputModal**
- [x] **PageMain→DeleteModal**
+ setSelectToDo
- [x] PageMain→Card
+ modal
- [x] PageMain
+ setModal
- [x] PageMain→Card
- [x] PageMain→DescriptionModal
- [x] PageMain→InputModal
- [x] **PageMain→DeleteModal**
+ id　→　以降は不要（toDosに入っている分を使うので。）
- [ ] PageMain→Card
- [ ] PageMain→InputModal
+ setId
- [x] PageMain→InputModal

useStateを使う場合はどの階層で状態管理をするかを考える！
下位に受け渡して下位で更新することはできるが、上位に受け渡すことはできない！
close #8 

